### PR TITLE
Include `ray_julia_jll` CI build cache name

### DIFF
--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -61,11 +61,11 @@ jobs:
         uses: actions/cache/restore@v3
         id: build-cache
         with:
-          key: build-cache.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
+          key: build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
           path: ~/.cache
           restore-keys: |
-            build-cache.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
-            build-cache.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
+            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
+            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
       # Based upon:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full


### PR DESCRIPTION
Matches what we already had for the Ray.jl build cache.