### PR TITLE
Deterministic async `Ray.get` tests

### DIFF
--- a/test/object_store.jl
+++ b/test/object_store.jl
@@ -1,5 +1,4 @@
 @testset "object_store.jl" begin
-
     @testset "Put/Get roundtrip for $(typeof(x))" for x in (
         1, 1.23, "hello", (1, 2, 3), [1, 2, 3],
     )

--- a/test/task.jl
+++ b/test/task.jl
@@ -184,13 +184,18 @@ end
 
 # do this after the many tasks testset so we have workers warmed up
 @testset "Async support for ObjectRef" begin
-    obj_ref = submit_task(sleep, (10,))
+    obj_ref = submit_task(sleep, (3,))
     t = @async Ray.get(obj_ref)
     yield()
 
     # If C++ blocks then the task will complete prior to running these tests
     @test istaskstarted(t)
     @test !istaskdone(t)
+
+    # If we don't wait for the task to complete and the task is still running after the
+    # driver is shutdown we'll see the error: `ERROR: Package Ray errored during testing`
+    # https://github.com/beacon-biosignals/Ray.jl/issues/96
+    wait(t)
 end
 
 @testset "task resource requests" begin

--- a/test/task.jl
+++ b/test/task.jl
@@ -183,16 +183,14 @@ end
 end
 
 # do this after the many tasks testset so we have workers warmed up
-@testset "Async waiting on task" begin
-    sleep_t = t -> (sleep(t); t)
-    results = []
-    t1 = @async push!(results, Ray.get(submit_task(sleep_t, (10,))))
-    t2 = @async push!(results, Ray.get(submit_task(sleep_t, (1,))))
+@testset "Async support for ObjectRef" begin
+    obj_ref = submit_task(sleep, (10,))
+    t = @async Ray.get(obj_ref)
+    yield()
 
-    wait(t1)
-    wait(t2)
-
-    @test results == [1, 10]
+    # If C++ blocks then the task will complete prior to running these tests
+    @test istaskstarted(t)
+    @test !istaskdone(t)
 end
 
 @testset "task resource requests" begin


### PR DESCRIPTION
Fixes #92. I temporarily set `ray_jll.get(oid, -1)` to validate these tests fail when C++ blocks.