### PR TITLE
wrap `CoreWorker::Contains`

### DIFF
--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -210,6 +210,16 @@ std::shared_ptr<RayObject> get(const ObjectID object_id, int64_t timeout_ms) {
     return objects[0];
 }
 
+bool contains(const ObjectID object_id) {
+    auto &worker = CoreWorkerProcess::GetCoreWorker();
+    bool has_object;
+    auto status = worker.Contains(object_id, &has_object);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+    return has_object;
+}
+
 std::string ToString(ray::FunctionDescriptor function_descriptor)
 {
     return function_descriptor->ToString();
@@ -556,6 +566,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
 
     mod.method("put", &put);
     mod.method("get", &get);
+    mod.method("contains", &contains);
 
     mod.add_type<Status>("Status")
         .method("ok", &Status::ok)

--- a/ray_julia_jll/test/function_descriptor.jl
+++ b/ray_julia_jll/test/function_descriptor.jl
@@ -1,3 +1,5 @@
+using ray_julia_jll: JuliaFunctionDescriptor, function_descriptor
+
 @testset "function descriptor" begin
     fd = function_descriptor(isless)
 

--- a/ray_julia_jll/test/put_get.jl
+++ b/ray_julia_jll/test/put_get.jl
@@ -3,11 +3,17 @@ using ray_julia_jll: LocalMemoryBuffer, Data
 using ray_julia_jll: RayObject, GetData
 using ray_julia_jll: ObjectID
 
-@testset "put / get" begin
+@testset "put / get / contains" begin
+    @testset "contains" begin
+        oid = ray_julia_jll.ObjectIDFromRandom()
+        @test !ray_julia_jll.contains(oid)
+    end
+
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
         oid = put(RayObject(buffer), StdVector{ObjectID}())
+        @test ray_julia_jll.contains(oid)
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/Ray.jl/issues/55
@@ -28,6 +34,7 @@ using ray_julia_jll: ObjectID
         data = "Greetings from Julia!"
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
         oid = put(RayObject(buffer), StdVector{ObjectID}())
+        @test ray_julia_jll.contains(oid)
 
         ray_obj = get(oid, -1)
         buffer = GetData(ray_obj[])

--- a/ray_julia_jll/test/runtests.jl
+++ b/ray_julia_jll/test/runtests.jl
@@ -1,6 +1,6 @@
 using CxxWrap
 using Test
-using ray_julia_jll: JuliaFunctionDescriptor, function_descriptor
+using ray_julia_jll: ray_julia_jll
 
 include("utils.jl")
 


### PR DESCRIPTION
This will provide support for `wait`/`isready`/`get` polling without data movement.

There's an additional output that I'm not capturing (whether something is local vs. in plasma store); I don't think that it's really necessary and we can always add a flag or another function to check for only local or only plasma later if need be.