### PR TITLE
Add `has_owner` accessor for `ObjectRef`

### DIFF
--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -343,9 +343,7 @@ std::string serialize_job_config_json(const std::string &job_config_json) {
     RAY_CHECK(google::protobuf::util::JsonStringToMessage(job_config_json,
                                                           job_config.get()).ok());
 
-    std::string serialized;
-    job_config->SerializeToString(&serialized);
-    return serialized;
+    return job_config->SerializeAsString();
 }
 
 // Investigating OverrideTaskOrActorRuntimeEnvInfo
@@ -527,11 +525,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/protobuf/common.proto#L86
     mod.add_type<rpc::Address>("Address")
         .constructor<>()
-        .method("SerializeToString", [](const rpc::Address &addr) {
-            std::string serialized;
-            addr.SerializeToString(&serialized);
-            return serialized;
-        })
+        .method("SerializeAsString", &rpc::Address::SerializeAsString)
         .method("MessageToJsonString", [](const rpc::Address &addr) {
             std::string json;
             google::protobuf::util::MessageToJsonString(addr, &json);

--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -561,6 +561,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("GetCurrentJobId", &ray::core::CoreWorker::GetCurrentJobId)
         .method("GetCurrentTaskId", &ray::core::CoreWorker::GetCurrentTaskId)
         .method("GetRpcAddress", &ray::core::CoreWorker::GetRpcAddress)
+        .method("GetOwnerAddress", &ray::core::CoreWorker::GetOwnerAddress)
         .method("GetObjectRefs", &ray::core::CoreWorker::GetObjectRefs);
     mod.method("_GetCoreWorker", &_GetCoreWorker);
 

--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -426,6 +426,13 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         return keys;
     });
 
+    // class Status
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/status.h#L127
+    mod.add_type<Status>("Status")
+        .method("ok", &Status::ok)
+        .method("message", &Status::message)
+        .method("ToString", &Status::ToString);
+
     // TODO: Make `JobID` is a subclass of `BaseID`. The use of templating makes this more work
     // than normal.
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/id.h#L106
@@ -567,9 +574,6 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     mod.method("get", &get);
     mod.method("contains", &contains);
 
-    mod.add_type<Status>("Status")
-        .method("ok", &Status::ok)
-        .method("ToString", &Status::ToString);
     mod.add_type<JuliaGcsClient>("JuliaGcsClient")
         .constructor<const std::string&>()
         .method("Connect", &JuliaGcsClient::Connect)

--- a/ray_julia_jll/src/wrappers/any.jl
+++ b/ray_julia_jll/src/wrappers/any.jl
@@ -83,6 +83,16 @@ function Base.propertynames(::Type{WorkerType}, private::Bool=false)
     end
 end
 
+function check_status(status::Status)
+    ok(status) && return nothing
+
+    msg = message(status)
+
+    # TODO: Implement throw custom exception types like in:
+    # _raylet.pyx:437
+    error(msg)
+end
+
 #####
 ##### Function descriptor wrangling
 #####

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -17,6 +17,16 @@ function Base.show(io::IO, obj_ref::ObjectRef)
     return nothing
 end
 
+# Mirrors the functionality of the Python Ray function `get_owner_address`
+# https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L3308
+function get_owner_address(obj_ref::ObjectRef)
+    worker = ray_jll.GetCoreWorker()
+    owner_address = ray_jll.Address()
+    status = ray_jll.GetOwnerAddress(worker, obj_ref.oid, CxxPtr(owner_address))
+    ray_jll.check_status(status)
+    return owner_address
+end
+
 # We cannot serialize pointers between processes
 function Serialization.serialize(s::AbstractSerializer, obj_ref::ObjectRef)
     serialize_type(s, typeof(obj_ref))

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -27,6 +27,11 @@ function get_owner_address(obj_ref::ObjectRef)
     return owner_address
 end
 
+# TODO: A more efficiently `CoreWorker::HasOwner` exists but is private
+function has_owner(obj_ref::ObjectRef)
+    return !isempty(ray_jll.SerializeAsString(get_owner_address(obj_ref)))
+end
+
 # We cannot serialize pointers between processes
 function Serialization.serialize(s::AbstractSerializer, obj_ref::ObjectRef)
     serialize_type(s, typeof(obj_ref))

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -29,7 +29,10 @@ end
 
 # TODO: A more efficiently `CoreWorker::HasOwner` exists but is private
 function has_owner(obj_ref::ObjectRef)
-    return !isempty(ray_jll.SerializeAsString(get_owner_address(obj_ref)))
+    worker = ray_jll.GetCoreWorker()
+    owner_address = ray_jll.Address()
+    status = ray_jll.GetOwnerAddress(worker, obj_ref.oid, CxxPtr(owner_address))
+    return !isempty(ray_jll.SerializeAsString(owner_address))
 end
 
 # We cannot serialize pointers between processes

--- a/test/task.jl
+++ b/test/task.jl
@@ -41,6 +41,17 @@
     @test Ray.get(Ray.get(obj_ref2)) == 1
 end
 
+@testset "object ownership" begin
+    obj_ref1 = submit_task(Ray.put, (1,))
+    obj_ref2 = Ray.get(obj_ref1)
+    @test obj_ref2 isa ObjectRef
+    @test Ray.has_owner(obj_ref1)
+    @test !Ray.has_owner(obj_ref2)
+
+    msg = "An application is trying to access a Ray object whose owner is unknown"
+    @test_throws msg Ray.get_owner_address(obj_ref2)
+end
+
 @testset "Task spawning a task" begin
     # As tasks may be run on the same worker it's better to use the task ID rather than the
     # process ID.


### PR DESCRIPTION
Was found to be useful in determining if an ObjectID has been registered with the core worker. If an `ObjectRef` does not have an owner then a `Ray.get` call will wait indefinitely. See https://github.com/beacon-biosignals/Ray.jl/issues/77#issuecomment-1712129853 for details.