### PR TITLE
Support `readheader` with `RaySerializer`

### DIFF
--- a/src/Ray.jl
+++ b/src/Ray.jl
@@ -14,7 +14,7 @@ using Logging
 using LoggingExtras
 using Pkg
 using Serialization: Serialization, AbstractSerializer, Serializer, deserialize,
-    reset_state, serialize, serialize_type, ser_version, writeheader
+    reset_state, serialize, serialize_type, writeheader
 
 import ray_julia_jll as ray_jll
 

--- a/src/Ray.jl
+++ b/src/Ray.jl
@@ -14,7 +14,7 @@ using Logging
 using LoggingExtras
 using Pkg
 using Serialization: Serialization, AbstractSerializer, Serializer, deserialize,
-    reset_state, serialize, serialize_type, writeheader
+    reset_state, serialize, serialize_type, ser_version, writeheader
 
 import ray_julia_jll as ray_jll
 

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -4,12 +4,13 @@ mutable struct RaySerializer{I<:IO} <: AbstractSerializer
     counter::Int
     table::IdDict{Any,Any}
     pending_refs::Vector{Int}
+    version::Int
 
     # Inlined object references encountered during serializing
     object_refs::Set{ObjectRef}
 
     function RaySerializer{I}(io::I) where I<:IO
-        return new(io, 0, IdDict(), Int[], Set{ObjectRef}())
+        return new(io, 0, IdDict(), Int[], ser_version, Set{ObjectRef}())
     end
 end
 

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -10,7 +10,7 @@ mutable struct RaySerializer{I<:IO} <: AbstractSerializer
     object_refs::Set{ObjectRef}
 
     function RaySerializer{I}(io::I) where I<:IO
-        return new(io, 0, IdDict(), Int[], ser_version, Set{ObjectRef}())
+        return new(io, 0, IdDict(), Int[], Serialization.ser_version, Set{ObjectRef}())
     end
 end
 

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -34,6 +34,19 @@
         Serialization.reset_state(s)
         @test isempty(s.object_refs)
     end
+
+    @testset "header support" begin
+        bytes = Vector{UInt8}()
+        s = Ray.RaySerializer(IOBuffer(bytes; write=true))
+        Serialization.writeheader(s)
+
+        s = Ray.RaySerializer(IOBuffer(bytes))
+        b = Int32(read(s.io, UInt8)::UInt8)
+        @test b == Serialization.HEADER_TAG
+
+        # Using `readheader` requires the serializer to have the `version` field
+        @test Serialization.readheader(s) === nothing
+    end
 end
 
 @testset "serialize_to_bytes / deserialize_from_bytes" begin


### PR DESCRIPTION
While debugging a serialization issue with #77 it was noticed that `readheader` couldn't be called on a `RaySerializer`. This PR adds the `version` field so that this call succeeds.

Without this change a `deserialize(::RaySerializer)` call will fail. We haven't seen this issue before as we've only been using `RaySerializer` for serialization so far.