### PR TITLE
Ensure `inlined_ids` eltype of `StdVector` is correct

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -234,8 +234,8 @@ function serialize_args(args)
 
         buffer = ray_jll.LocalMemoryBuffer(serialized_arg, serialized_arg_size, true)
         metadata = ray_jll.NullPtr(ray_jll.Buffer)
-        inlined_ids = collect(serializer.object_ids)
-        inlined_refs = ray_jll.GetObjectRefs(worker, StdVector(inlined_ids))
+        inlined_ids = StdVector(collect(serializer.object_ids))::StdVector{ray_jll.ObjectID}
+        inlined_refs = ray_jll.GetObjectRefs(worker, inlined_ids)
         ray_obj = ray_jll.RayObject(buffer, metadata, inlined_refs, false)
 
         # Inline arguments which are small and if there is room
@@ -329,8 +329,8 @@ function task_executor(ray_function, returns_ptr, task_args_ptr, task_name,
 
     buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
     metadata = ray_jll.NullPtr(ray_jll.Buffer)
-    inlined_ids = collect(serializer.object_ids)
-    inlined_refs = ray_jll.GetObjectRefs(worker, StdVector(inlined_ids))
+    inlined_ids = StdVector(collect(serializer.object_ids))::StdVector{ray_jll.ObjectID}
+    inlined_refs = ray_jll.GetObjectRefs(worker, inlined_ids)
     ray_obj = ray_jll.RayObject(buffer, metadata, inlined_refs, false)
     push!(returns, ray_obj)
 

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -10,7 +10,7 @@
 
     @testset "object_ids property" begin
         s = Ray.RaySerializer(IOBuffer())
-        @test s.object_ids isa Set{<:ray_jll.ObjectID}
+        @test s.object_ids isa Set{ray_jll.ObjectIDAllocated}
     end
 
     @testset "inlined object refs" begin
@@ -21,7 +21,9 @@
         s = Ray.RaySerializer(IOBuffer())
         serialize(s, x)
 
+        @test s.object_refs isa Set{ObjectRef}
         @test s.object_refs == Set(obj_refs)
+        @test s.object_ids isa Set{ray_jll.ObjectIDAllocated}
         @test s.object_ids == Set(oids)
     end
 


### PR DESCRIPTION
The `GetObjectRefs` function requires that a `StdVector{ObjectID}` is passed in for the `inlined_ids` argument. If we update `serializer.object_ids` to return a `Set{ObjectID}` things break in an unexpected way as `StdVector(collect(Set{ObjectID}())) isa StdVector{Any}` where as `StdVector(collect(Set{ObjectIDAllocated}())) isa StdVector{ObjectID}`.

Here's an overview which may help those trying to understand what's going on:

```julia
julia> using ray_julia_jll: ObjectID, ObjectIDAllocated

julia> using CxxWrap.StdLib: StdVector

julia> StdVector(ObjectIDAllocated[])
0-element CxxWrap.StdLib.StdVectorAllocated{ObjectID}

julia> StdVector(ObjectID[])
0-element CxxWrap.StdLib.StdVectorAllocated{Any}

julia> StdVector{ObjectID}(ObjectIDAllocated[])
ERROR: MethodError: no method matching StdVector{ObjectID}(::Vector{ObjectIDAllocated})

Closest candidates are:
  StdVector{ObjectID}()
   @ ray_julia_jll ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624

Stacktrace:
 [1] top-level scope
   @ REPL[10]:1

julia> StdVector(ObjectIDAllocated[])::StdVector{ObjectID}
0-element CxxWrap.StdLib.StdVectorAllocated{ObjectID}

julia> StdVector(ObjectID[])::StdVector{ObjectID}
ERROR: TypeError: in typeassert, expected StdVector{ObjectID}, got a value of type CxxWrap.StdLib.StdVectorAllocated{Any}
Stacktrace:
 [1] top-level scope
   @ REPL[12]:1
```

The type checks here should provide some protection about accidental changes.

Related to: https://github.com/JuliaInterop/CxxWrap.jl/issues/367