### PR TITLE
Make `start_worker` positional argument optional

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -397,7 +397,7 @@ function start_worker(args=ARGS)
             arg_type=Int
             default=0
         "arg1"
-            required = true
+            required = false
     end
 
     parsed_args = parse_args(args, s)


### PR DESCRIPTION
Allows us to merge https://github.com/beacon-biosignals/ray/pull/9 without breaking our Ray.jl CI.