### PR TITLE
Wrap parent class for all protobuf messages

### DIFF
--- a/ray_julia_jll/Project.toml
+++ b/ray_julia_jll/Project.toml
@@ -17,15 +17,18 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 [compat]
 CxxWrap = "0.13.4"
 JLLWrappers = "1.2.0"
+JSON3 = "1"
 Mustache = "1"
 TOML = "1"
 julia = "1.6"
 libcxxwrap_julia_jll = "0.9.7"
 
 [extras]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Serialization", "Test", "UUIDs"]
+test = ["Base64", "JSON3", "Serialization", "Test", "UUIDs"]

--- a/ray_julia_jll/deps/wrapper.h
+++ b/ray_julia_jll/deps/wrapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <google/protobuf/message.h>
 
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/functions.hpp"

--- a/ray_julia_jll/src/wrappers/any.jl
+++ b/ray_julia_jll/src/wrappers/any.jl
@@ -132,6 +132,22 @@ function GetCoreWorker()
 end
 
 #####
+##### Message
+#####
+
+function ParseFromString(::Type{T}, str::AbstractString) where T <: Message
+    message = T()
+    ParseFromString(message, str)
+    return message
+end
+
+function JsonStringToMessage(::Type{T}, json::AbstractString) where T <: Message
+    message = T()
+    JsonStringToMessage(json, CxxPtr(message))
+    return message
+end
+
+#####
 ##### Buffer
 #####
 

--- a/ray_julia_jll/test/address.jl
+++ b/ray_julia_jll/test/address.jl
@@ -1,0 +1,19 @@
+using ray_julia_jll: Address
+
+@testset "Address" begin
+    @testset "json round-trip" begin
+        json = Dict(:rayletId => base64encode("raylet"), :ipAddress => "127.0.0.1",
+                    :port => 10000, :workerId => base64encode("worker"))
+        json_str = JSON3.write(json)
+        address = ray_julia_jll.JsonStringToMessage(Address, json_str)
+        result = ray_julia_jll.MessageToJsonString(address)
+        @test JSON3.read(String(result)) == json
+    end
+
+    @testset "serialized round-trip" begin
+        serialized_str = "\n\x06raylet\x12\t127.0.0.1\x18\x90N\"\x06worker"
+        address = ray_julia_jll.ParseFromString(Address, serialized_str)
+        result = ray_julia_jll.SerializeAsString(address)
+        @test result == serialized_str
+    end
+end

--- a/ray_julia_jll/test/runtests.jl
+++ b/ray_julia_jll/test/runtests.jl
@@ -1,4 +1,6 @@
+using Base64: base64encode
 using CxxWrap
+using JSON3: JSON3
 using Test
 using ray_julia_jll: ray_julia_jll
 
@@ -11,6 +13,7 @@ end
 @testset "ray_julia_jll.jl" begin
     include("buffer.jl")
     include("function_descriptor.jl")
+    include("address.jl")
 
     setup_ray_head_node() do
         # GCS client only needs head node

--- a/src/runtime_env.jl
+++ b/src/runtime_env.jl
@@ -61,7 +61,8 @@ end
 # https://github.com/beacon-biosignals/Ray.jl/issues/57
 function _serialize(job_config::JobConfig)
     job_config_json = JSON3.write(json_dict(job_config))
-    return ray_jll.serialize_job_config_json(job_config_json)
+    rpc_job_config = ray_jll.JsonStringToMessage(ray_jll.JobConfig, job_config_json)
+    return ray_jll.SerializeAsString(rpc_job_config)
 end
 
 function process_import_statements(ex::Expr)


### PR DESCRIPTION
I had a couple notes on wrapping protobuf messages in Julia I wanted to add into our wrapper code and ended up implementing a wrapper for `google::protobuf::Message` which is the parent class of all of the `message X` protobuf code. Effectively this just makes it easier to wrap additional protobuf messages.