### PR TITLE
Tweaks to JobID

### DIFF
--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -16,8 +16,6 @@ void initialize_driver(
     options.language = Language::JULIA;
     options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = raylet_socket;  // Required by `RayletClient`
-    // XXX: this is hard coded! very bad!!! should use global state accessor to
-    // get next job id instead
     options.job_id = job_id;
     options.gcs_options = gcs::GcsClientOptions(gcs_address);
     options.enable_logging = !logs_dir.empty();

--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -459,8 +459,8 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // than normal.
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/id.h#L106
     mod.add_type<JobID>("JobID")
-        .method("ToInt", &JobID::ToInt)
-        .method("FromInt", &JobID::FromInt);
+        .method("JobIDFromInt", &JobID::FromInt)
+        .method("ToInt", &JobID::ToInt);
 
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/id.h#L175
     mod.add_type<TaskID>("TaskID")

--- a/ray_julia_jll/src/wrappers/any.jl
+++ b/ray_julia_jll/src/wrappers/any.jl
@@ -120,7 +120,7 @@ function Base.getproperty(fd::JuliaFunctionDescriptor, field::Symbol)
 end
 
 Base.show(io::IO, status::Status) = print(io, ToString(status))
-Base.show(io::IO, jobid::JobID) = print(io, Int(ToInt(jobid)))
+Base.show(io::IO, jobid::JobID) = print(io, ToInt(jobid))
 
 const CORE_WORKER = Ref{CoreWorker}()
 
@@ -152,6 +152,12 @@ end
 #####
 
 NullPtr(::Type{Buffer}) = BufferFromNull()
+
+#####
+##### JobID
+#####
+
+FromInt(::Type{JobID}, num::Integer) = JobIDFromInt(num)
 
 #####
 ##### ObjectID

--- a/ray_julia_jll/test/utils.jl
+++ b/ray_julia_jll/test/utils.jl
@@ -1,4 +1,4 @@
-using ray_julia_jll: initialize_driver, shutdown_driver, FromInt
+using ray_julia_jll: initialize_driver, shutdown_driver, FromInt, JobID
 
 function setup_ray_head_node(body)
     prestarted = success(`ray status`)
@@ -34,7 +34,7 @@ function setup_core_worker(body)
                       "127.0.0.1:6379",
                       "127.0.0.1",
                       node_manager_port(),
-                      FromInt(1234),
+                      FromInt(JobID, 1234),
                       "/tmp/ray/session_latest/logs/",
                       "")
     try

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -117,7 +117,7 @@ end
 Get the current job ID for this worker or driver. Job ID is the id of your Ray drivers that
 create tasks.
 """
-get_job_id() = ray_jll.ToInt(ray_jll.GetCurrentJobId(ray_jll.GetCoreWorker()))
+get_job_id() = ray_jll.ToInt(ray_jll.GetCurrentJobId(ray_jll.GetCoreWorker()))::UInt32
 
 """
     get_task_id() -> String


### PR DESCRIPTION
- Wraps `JobID::FromInt` as `JobIDFromInt` instead of just `FromInt` to avoid future collisions (similar to what we did for `ObjectID`
- Implement `FromInt(::Type{JobID}, num::Integer)`
- Display `JobID` as a hexadecimal (via unsigned int)
- Use type assertion to ensure that `get_job_id` docstring is accurate