### PR TITLE
Pass through metadata into JobConfig

### DIFF
--- a/ray_julia_jll/deps/wrapper.cc
+++ b/ray_julia_jll/deps/wrapper.cc
@@ -674,9 +674,15 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
             return std::unique_ptr<TaskArgByValue>(t);
         });
 
+    // class WorkerContext
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/context.h#L30
+    mod.add_type<ray::core::WorkerContext>("WorkerContext")
+        .method("GetCurrentJobConfig", &ray::core::WorkerContext::GetCurrentJobConfig);
+
     // class CoreWorker
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/core_worker.h#L284
     mod.add_type<ray::core::CoreWorker>("CoreWorker")
+        .method("GetWorkerContext", &ray::core::CoreWorker::GetWorkerContext)
         .method("GetCurrentJobId", &ray::core::CoreWorker::GetCurrentJobId)
         .method("GetCurrentTaskId", &ray::core::CoreWorker::GetCurrentTaskId)
         .method("GetRpcAddress", &ray::core::CoreWorker::GetRpcAddress)

--- a/src/runtime_env.jl
+++ b/src/runtime_env.jl
@@ -53,10 +53,17 @@ end
 # https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/protobuf/common.proto#L324-L349
 struct JobConfig
     runtime_env_info::RuntimeEnvInfo
+    metadata::Dict{String,String}
 end
 
+JobConfig(; runtime_env_info, metadata=Dict()) = JobConfig(runtime_env_info, metadata)
+
 function json_dict(job_config::JobConfig)
-    return Dict("runtime_env_info" => json_dict(job_config.runtime_env_info))
+    json = Dict("runtime_env_info" => json_dict(job_config.runtime_env_info))
+    if !isempty(job_config.metadata)
+        json["metadata"] = job_config.metadata
+    end
+    return json
 end
 
 # TODO: We may want to use separate functions for protobuf serialization and JSON

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Aqua
 using Base64: Base64DecodePipe
 using CxxWrap: CxxPtr, StdVector
 using CxxWrap.StdLib: UniquePtr
+using JSON3: JSON3
 using Ray
 using Serialization
 using Test

--- a/test/runtime_env.jl
+++ b/test/runtime_env.jl
@@ -50,3 +50,32 @@ end
         @test result == package_imports
     end
 end
+
+@testset "JobConfig" begin
+    @testset "defaults" begin
+        @test_throws UndefKeywordError Ray.JobConfig()
+
+        runtime_env_info = Ray.RuntimeEnvInfo(Ray.RuntimeEnv())
+        job_config = Ray.JobConfig(; runtime_env_info)
+        @test job_config.runtime_env_info isa Ray.RuntimeEnvInfo
+        @test job_config.runtime_env_info == runtime_env_info
+        @test job_config.metadata isa Dict{String,String}
+        @test isempty(job_config.metadata)
+    end
+
+    @testset "json_dict" begin
+        runtime_env_info = Ray.RuntimeEnvInfo(Ray.RuntimeEnv())
+        metadata = Dict("job_submission_id" => "raysubmit_BzncEsVBi6uA3LA9",
+                        "job_name" => "raysubmit_BzncEsVBi6uA3LA9")
+
+        job_config = Ray.JobConfig(; runtime_env_info, metadata)
+        json = Ray.json_dict(job_config)
+        @test json["runtime_env_info"] == Ray.json_dict(runtime_env_info)
+        @test json["metadata"] == metadata
+
+        job_config = Ray.JobConfig(; runtime_env_info)
+        json = Ray.json_dict(job_config)
+        @test json["runtime_env_info"] == Ray.json_dict(runtime_env_info)
+        @test !haskey(json, "metadata")
+    end
+end


### PR DESCRIPTION
Improves Julia driver support for Ray job submissions. Fixes this issue on the dashboard where a job submission and the driver are separate entries:

![Screenshot 2023-09-18 at 14 30 34](https://github.com/beacon-biosignals/Ray.jl/assets/1675958/c1140cba-4f44-4270-8e72-cdccf19ff7db)
– https://github.com/beacon-biosignals/Ray.jl/pull/120#issuecomment-1724260426