### PR TITLE
Specify `JULIA_CPU_TARGET` for improved CPU compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN if ! julia --history-file=no -e 'exit(0)'; then \
 # Reduces output from `apt-get`
 ENV DEBIAN_FRONTEND="noninteractive"
 
+# Set x86_64 targets for improved compatibility
+# https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets
+ENV JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+
 #####
 ##### deps stage
 #####


### PR DESCRIPTION
While experimenting with our multi-node support with Ray.jl I noticed that the Docker image when deployed to K8s was performing precompilation even though we perform precompilation during the Docker image build.

From within the K8s head node I would see the following:
```sh
$ JULIA_DEBUG=loading julia -e 'using ray_julia_jll'
┌ Debug: Rejecting cache file /home/ray/.julia/compiled/v1.9/ray_julia_jll/u5r9n_66Sde.ji for ray_julia_jll [c348cde4-7f22-4730-83d8-6959fb7a17ba] since pkgimage can't be loaded on this target
└ @ Base loading.jl:2746
...
```
After a brief investigation I noticed that the `Sys.CPU_NAME` on my image build machine was `"znver3"` (AMD) while on my K8s head node it was `"cascadelake"` (Intel). The [official Julia binaries specify the CPU target as](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets):
```sh
JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
```
So I did the same in our Docker image and found this addressed the problem.

Depends on #130
