### PR TITLE
Improve display of task exceptions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 ray_julia_jll = "c348cde4-7f22-4730-83d8-6959fb7a17ba"
 
 [compat]

--- a/src/Ray.jl
+++ b/src/Ray.jl
@@ -15,11 +15,13 @@ using LoggingExtras
 using Pkg
 using Serialization: Serialization, AbstractSerializer, Serializer, deserialize,
     reset_state, serialize, serialize_type, ser_version, writeheader
+using Sockets: IPAddr, getipaddr
 
 import ray_julia_jll as ray_jll
 
 export start_worker, submit_task, @ray_import, ObjectRef
 
+include("exceptions.jl")
 include("function_manager.jl")
 include("runtime_env.jl")
 include("remote_function.jl")

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -17,6 +17,6 @@ function Base.showerror(io::IO, ex::RayTaskException, bt=nothing; backtrace=true
         println(io)
     end
     printstyled(io, "\nnested exception: ", color=Base.error_color())
-    # TODO: `showerror(io::IO, ex::CapturedException)` should accept `backtrace` keyword
+    # Call 3-argument `showerror` to allow specifying `backtrace`
     showerror(io, ex.captured.ex, ex.captured.processed_bt; backtrace)
 end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -2,15 +2,16 @@ struct RayTaskException <: Exception
     task_name::String
     pid::Int
     ip::IPAddr
+    task_id::String
     captured::CapturedException
 end
 
 function RayTaskException(task_name::AbstractString, captured::CapturedException)
-    return RayTaskException(task_name, getpid(), getipaddr(), captured)
+    return RayTaskException(task_name, getpid(), getipaddr(), get_task_id(), captured)
 end
 
 function Base.showerror(io::IO, ex::RayTaskException, bt=nothing; backtrace=true)
-    print(io, "RayTaskException: $(ex.task_name) (pid=$(ex.pid), ip=$(ex.ip))")
+    print(io, "RayTaskException: $(ex.task_name) (pid=$(ex.pid), ip=$(ex.ip), task_id=$(ex.task_id))")
     if backtrace
         bt !== nothing && Base.show_backtrace(io, bt)
         println(io)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,20 @@
+struct RayTaskException <: Exception
+    task_name::String
+    pid::Int
+    ip::IPAddr
+    captured::CapturedException
+end
+
+function RayTaskException(task_name::AbstractString, captured::CapturedException)
+    return RayTaskException(task_name, getpid(), getipaddr(), captured)
+end
+
+function Base.showerror(io::IO, ex::RayTaskException, bt=nothing; backtrace=true)
+    print(io, "RayTaskException: $(ex.task_name) (pid=$(ex.pid), ip=$(ex.ip))")
+    if bt !== nothing && backtrace
+        Base.show_backtrace(io, bt)
+    end
+    println(io)
+    printstyled(io, "\nnested exception: ", color=Base.error_color())
+    showerror(io, ex.captured.ex, ex.captured.processed_bt; backtrace)
+end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -11,10 +11,11 @@ end
 
 function Base.showerror(io::IO, ex::RayTaskException, bt=nothing; backtrace=true)
     print(io, "RayTaskException: $(ex.task_name) (pid=$(ex.pid), ip=$(ex.ip))")
-    if bt !== nothing && backtrace
-        Base.show_backtrace(io, bt)
+    if backtrace
+        bt !== nothing && Base.show_backtrace(io, bt)
+        println(io)
     end
-    println(io)
     printstyled(io, "\nnested exception: ", color=Base.error_color())
+    # TODO: `showerror(io::IO, ex::CapturedException)` should accept `backtrace` keyword
     showerror(io, ex.captured.ex, ex.captured.processed_bt; backtrace)
 end

--- a/src/object_store.jl
+++ b/src/object_store.jl
@@ -56,7 +56,7 @@ function _get(bytes::Vector{UInt8}, outer_obj_ref::Union{ObjectRef,Nothing})
 
     # TODO: add an option to not rethrow
     # https://github.com/beacon-biosignals/Ray.jl/issues/58
-    result isa RayRemoteException ? throw(result) : return result
+    result isa RayTaskException ? throw(result) : return result
 end
 
 """

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -20,17 +20,6 @@ function _ray_import(runtime_env::RuntimeEnv)
     return nothing
 end
 
-struct RayRemoteException <: Exception
-    pid::Int
-    task_name::String
-    captured::CapturedException
-end
-
-function Base.showerror(io::IO, re::RayRemoteException)
-    print(io, "on Ray task \"$(re.task_name)\" with PID $(re.pid): ")
-    showerror(io, re.captured)
-end
-
 """
     const GLOBAL_STATE_ACCESSOR::Ref{ray_jll.GlobalStateAccessor}
 
@@ -313,7 +302,7 @@ function task_executor(ray_function, returns_ptr, task_args_ptr, task_name,
         is_retryable_error[] = ray_jll.CxxBool(false)
         @debug "push error status: $status"
 
-        result = RayRemoteException(getpid(), task_name, captured)
+        result = RayTaskException(task_name, captured)
     end
 
     # TODO: remove - useful for now for debugging

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -1,0 +1,24 @@
+@testset "RayTaskException" begin
+    @testset "showerror" begin
+        e = ErrorException("foo")
+        e = Ray.RayTaskException("test2", 2, ip"127.0.0.1", CapturedException(e, backtrace()))
+        rte = Ray.RayTaskException("test1", 1, ip"127.0.0.1", CapturedException(e, backtrace()))
+
+        str = sprint(showerror, rte)
+        @test occursin(r"\A\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\Qnested exception: foo\E"m, str)
+
+        structure_regex = r"""
+            ^RayTaskException:[^\n]++
+
+            nested exception: RayTaskException[^\n]++
+            Stacktrace:
+              ([^\n]++\n?)+
+
+            nested exception: foo
+            Stacktrace:
+              ([^\n]++\n?)+$"""s
+        @test occursin(structure_regex, str)
+    end
+end

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -5,14 +5,14 @@
         rte = Ray.RayTaskException("test1", 1, ip"127.0.0.1", CapturedException(e, backtrace()))
 
         str = sprint(showerror, rte)
-        @test occursin(r"\A\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
         @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1)\E"m, str)
         @test occursin(r"^\Qnested exception: foo\E"m, str)
 
         structure_regex = r"""
-            ^RayTaskException:[^\n]++
+            ^RayTaskException: test1[^\n]++
 
-            nested exception: RayTaskException[^\n]++
+            nested exception: RayTaskException: test2[^\n]++
             Stacktrace:
               ([^\n]++\n?)+
 

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -20,5 +20,18 @@
             Stacktrace:
               ([^\n]++\n?)+$"""s
         @test occursin(structure_regex, str)
+
+        str = sprint(rte) do io, args...
+            showerror(io, args...; backtrace=false)
+        end
+        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\Qnested exception: foo\E"m, str)
+
+        structure_regex = r"""
+            ^RayTaskException: test1[^\n]++
+            nested exception: RayTaskException: test2[^\n]++
+            nested exception: foo$"""s
+        @test occursin(structure_regex, str)
     end
 end

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -1,12 +1,12 @@
 @testset "RayTaskException" begin
     @testset "showerror" begin
         e = ErrorException("foo")
-        e = Ray.RayTaskException("test2", 2, ip"127.0.0.1", CapturedException(e, backtrace()))
-        rte = Ray.RayTaskException("test1", 1, ip"127.0.0.1", CapturedException(e, backtrace()))
+        e = Ray.RayTaskException("test2", 2, ip"127.0.0.1", "t2", CapturedException(e, backtrace()))
+        rte = Ray.RayTaskException("test1", 1, ip"127.0.0.1", "t1", CapturedException(e, backtrace()))
 
         str = sprint(showerror, rte)
-        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
-        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1, task_id=t1)\E"m, str)
+        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1, task_id=t2)\E"m, str)
         @test occursin(r"^\Qnested exception: foo\E"m, str)
 
         structure_regex = r"""
@@ -24,8 +24,8 @@
         str = sprint(rte) do io, args...
             showerror(io, args...; backtrace=false)
         end
-        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1)\E"m, str)
-        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1)\E"m, str)
+        @test occursin(r"^\QRayTaskException: test1 (pid=1, ip=127.0.0.1, task_id=t1)\E"m, str)
+        @test occursin(r"^\Qnested exception: RayTaskException: test2 (pid=2, ip=127.0.0.1, task_id=t2)\E"m, str)
         @test occursin(r"^\Qnested exception: foo\E"m, str)
 
         structure_regex = r"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using CxxWrap: CxxPtr, StdVector
 using CxxWrap.StdLib: UniquePtr
 using Ray
 using Serialization
+using Sockets: @ip_str
 using Test
 
 import ray_julia_jll as ray_jll
@@ -18,6 +19,7 @@ include("utils.jl")
         Aqua.test_all(Ray; ambiguities=false)
     end
 
+    include("exceptions.jl")
     include("runtime_env.jl")
     include("remote_function.jl")
 

--- a/test/task.jl
+++ b/test/task.jl
@@ -29,7 +29,7 @@
     try
         Ray.get(result)
     catch e
-        @test e isa Ray.RayRemoteException
+        @test e isa Ray.RayTaskException
         @test e.captured.ex == ErrorException("AHHHHH")
     end
 


### PR DESCRIPTION
Fixes: https://github.com/beacon-biosignals/Ray.jl/issues/135

Quick example:
```julia
julia> using Ray

julia> Ray.init()

julia> entrypoint = function (x)
           function f(x)
               if x > 3
                   throw(ErrorException("x > 3"))
               else
                   Ray.get(Ray.submit_task(f, (x + 1,)))
               end
           end

           return f(x)
       end
#3 (generic function with 1 method)

julia> Ray.get(Ray.submit_task(entrypoint, (1,)))
ERROR: RayTaskException: Main.#3 (pid=11196, ip=192.168.224.76, task_id=c8ef45ccd0112571ffffffffffffffffffffffff01000000)
Stacktrace:
 [1] _get(bytes::Vector{UInt8}, outer_obj_ref::ObjectRef)
   @ Ray ~/.julia/dev/Ray/src/object_store.jl:59
 [2] get(obj_ref::ObjectRef)
   @ Ray ~/.julia/dev/Ray/src/object_store.jl:31
 [3] top-level scope
   @ REPL[4]:1

nested exception: RayTaskException: Serialization.__deserialized_types__.f (pid=11208, ip=192.168.224.76, task_id=9930f5acb950220cffffffffffffffffffffffff01000000)
Stacktrace:
  [1] _get
    @ ~/.julia/dev/Ray/src/object_store.jl:59
  [2] get
    @ ~/.julia/dev/Ray/src/object_store.jl:31
  [3] f
    @ ./REPL[3]:6
  [4] #3
    @ ./REPL[3]:10
  [5] #invokelatest#2
    @ ./essentials.jl:819 [inlined]
  [6] invokelatest
    @ ./essentials.jl:816 [inlined]
  [7] #5#6
    @ ~/.julia/dev/Ray/src/function_manager.jl:128 [inlined]
  [8] #5
    @ ~/.julia/dev/Ray/src/function_manager.jl:128
  [9] task_executor
    @ ~/.julia/dev/Ray/src/runtime.jl:285
 [10] initialize_worker
    @ ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624
 [11] initialize_worker
    @ ~/.julia/dev/Ray/ray_julia_jll/src/wrappers/any.jl:246
 [12] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:410
 [13] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:341
 [14] top-level scope
    @ none:1
 [15] eval
    @ ./boot.jl:370 [inlined]
 [16] exec_options
    @ ./client.jl:280
 [17] _start
    @ ./client.jl:522

nested exception: RayTaskException: Serialization.__deserialized_types__.f (pid=11220, ip=192.168.224.76, task_id=e982e7eec9714708ffffffffffffffffffffffff01000000)
Stacktrace:
  [1] _get
    @ ~/.julia/dev/Ray/src/object_store.jl:59
  [2] get
    @ ~/.julia/dev/Ray/src/object_store.jl:31
  [3] f
    @ ./REPL[3]:6
  [4] #invokelatest#2
    @ ./essentials.jl:819 [inlined]
  [5] invokelatest
    @ ./essentials.jl:816 [inlined]
  [6] #5#6
    @ ~/.julia/dev/Ray/src/function_manager.jl:128 [inlined]
  [7] #5
    @ ~/.julia/dev/Ray/src/function_manager.jl:128
  [8] task_executor
    @ ~/.julia/dev/Ray/src/runtime.jl:285
  [9] initialize_worker
    @ ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624
 [10] initialize_worker
    @ ~/.julia/dev/Ray/ray_julia_jll/src/wrappers/any.jl:246
 [11] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:410
 [12] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:341
 [13] top-level scope
    @ none:1
 [14] eval
    @ ./boot.jl:370 [inlined]
 [15] exec_options
    @ ./client.jl:280
 [16] _start
    @ ./client.jl:522

nested exception: RayTaskException: Serialization.__deserialized_types__.f (pid=11261, ip=192.168.224.76, task_id=104ba58d0343339cffffffffffffffffffffffff01000000)
Stacktrace:
  [1] _get
    @ ~/.julia/dev/Ray/src/object_store.jl:59
  [2] get
    @ ~/.julia/dev/Ray/src/object_store.jl:31
  [3] f
    @ ./REPL[3]:6
  [4] #invokelatest#2
    @ ./essentials.jl:819 [inlined]
  [5] invokelatest
    @ ./essentials.jl:816 [inlined]
  [6] #5#6
    @ ~/.julia/dev/Ray/src/function_manager.jl:128 [inlined]
  [7] #5
    @ ~/.julia/dev/Ray/src/function_manager.jl:128
  [8] task_executor
    @ ~/.julia/dev/Ray/src/runtime.jl:285
  [9] initialize_worker
    @ ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624
 [10] initialize_worker
    @ ~/.julia/dev/Ray/ray_julia_jll/src/wrappers/any.jl:246
 [11] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:410
 [12] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:341
 [13] top-level scope
    @ none:1
 [14] eval
    @ ./boot.jl:370 [inlined]
 [15] exec_options
    @ ./client.jl:280
 [16] _start
    @ ./client.jl:522

nested exception: x > 3
Stacktrace:
  [1] f
    @ ./REPL[3]:4
  [2] #invokelatest#2
    @ ./essentials.jl:819 [inlined]
  [3] invokelatest
    @ ./essentials.jl:816 [inlined]
  [4] #5#6
    @ ~/.julia/dev/Ray/src/function_manager.jl:128 [inlined]
  [5] #5
    @ ~/.julia/dev/Ray/src/function_manager.jl:128
  [6] task_executor
    @ ~/.julia/dev/Ray/src/runtime.jl:285
  [7] initialize_worker
    @ ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624
  [8] initialize_worker
    @ ~/.julia/dev/Ray/ray_julia_jll/src/wrappers/any.jl:246
  [9] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:410
 [10] start_worker
    @ ~/.julia/dev/Ray/src/runtime.jl:341
 [11] top-level scope
    @ none:1
 [12] eval
    @ ./boot.jl:370 [inlined]
 [13] exec_options
    @ ./client.jl:280
 [14] _start
    @ ./client.jl:522
```