### PR TITLE
Refactor `Dockerfile` to be useful as a base image for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ FROM rayproject/ray:${RAY_VERSION}-py310 as ray-base
 
 # Install Julia
 COPY --link --from=julia-base /usr/local/julia /usr/local/julia
-ENV JULIA_PATH /usr/local/julia
-ENV PATH $JULIA_PATH/bin:$PATH
+ENV JULIA_PATH=/usr/local/julia
+ENV PATH=$JULIA_PATH/bin:$PATH
 
 # Validate Julia executable is compatible with the container architecture
 RUN if ! julia --history-file=no -e 'exit(0)'; then \
@@ -39,7 +39,7 @@ ENV JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,bas
 FROM ray-base as deps
 
 # Disable automatic package precompilation. We'll control when packages are precompiled.
-ENV JULIA_PKG_PRECOMPILE_AUTO "0"
+ENV JULIA_PKG_PRECOMPILE_AUTO="0"
 
 # Use the Git CLI when we are not using the Julia's PkgServer as otherwise Docker image
 # cross compilation can cause LibGit2 to run out of memory while cloning the General registry.
@@ -58,7 +58,7 @@ RUN --mount=type=cache,sharing=locked,target=/tmp/julia-cache,uid=1000,gid=100 \
     julia -e 'using Pkg; Pkg.Registry.add("General")'
 
 # Instantiate the Julia project environment
-ENV JULIA_PROJECT /Ray.jl
+ENV JULIA_PROJECT=/Ray.jl
 COPY --chown=ray *Project.toml *Manifest.toml ${JULIA_PROJECT}/
 
 # Generate a fake ray_julia_jll package just for instantiation
@@ -105,7 +105,7 @@ RUN sudo ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN node --version && \
     npm --version
 
-ENV JULIA_PROJECT /Ray.jl
+ENV JULIA_PROJECT=/Ray.jl
 ARG JLL_JULIA_PROJECT=${JULIA_PROJECT}/ray_julia_jll
 RUN sudo mkdir -p ${JULIA_PROJECT} && \
     sudo chown ray ${JULIA_PROJECT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV JULIA_PKG_USE_CLI_GIT="true"
 # path used during package precompilation matches the final depot path used in the image.
 # If a source file no longer resides at the expected location the `.ji` is deemed stale and
 # will be recreated.
-ARG JULIA_DEPOT_CACHE=/tmp/julia-cache
+ARG JULIA_DEPOT_CACHE=/mnt/julia-cache
 RUN ln -s ${JULIA_DEPOT_CACHE} ~/.julia
 
 # Install Julia package registries

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,sharing=locked,target=${JULIA_DEPOT_CACHE},uid=${UID},gid
     julia -e 'using Pkg; Pkg.Registry.add("General")'
 
 # Instantiate the Julia project environment
-ARG RAY_JL_PROJECT=/Ray.jl
+ARG RAY_JL_PROJECT=${HOME}/.julia/dev/Ray
 COPY --chown=ray *Project.toml *Manifest.toml ${RAY_JL_PROJECT}/
 
 # Generate a fake ray_julia_jll package just for instantiation
@@ -111,19 +111,15 @@ RUN sudo ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN node --version && \
     npm --version
 
-ARG RAY_JL_PROJECT=/Ray.jl
+ARG RAY_JL_PROJECT=${HOME}/.julia/dev/Ray
 ARG RAY_JLL_PROJECT=${RAY_JL_PROJECT}/ray_julia_jll
-RUN sudo mkdir -p ${JULIA_PROJECT} && \
-    sudo chown ray ${JULIA_PROJECT}
 
 # Install custom Ray CLI which supports the Julia language.
 # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
-ARG RAY_REPO=/ray
+ARG RAY_REPO=${HOME}/ray
 ARG RAY_COMMIT=448a83caf4
 ARG RAY_REPO_CACHE=/mnt/ray-cache
 ARG RAY_CACHE_CLEAR=false
-RUN sudo mkdir -p ${RAY_ROOT} && \
-    sudo chown ray ${RAY_ROOT}
 RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     --mount=type=cache,sharing=locked,target=${RAY_REPO_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
@@ -176,7 +172,7 @@ RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID
 COPY --chown=ray --link --from=deps ${HOME}/.julia ${HOME}/.julia
 
 # Setup ray_julia_jll
-ARG RAY_JLL_REPO=/ray_julia_jll
+ARG RAY_JLL_REPO=${HOME}/.julia/dev/ray_julia_jll
 COPY --chown=ray ray_julia_jll ${RAY_JLL_REPO}
 RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     set -eux && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,7 +203,10 @@ RUN rm -rf ${RAY_JLL_PROJECT} && \
     ln -s ${RAY_JLL_REPO} ${RAY_JLL_PROJECT}
 
 # Note: The `timing` flag requires Julia 1.9
-RUN julia -e 'using Pkg; Pkg.precompile(strict=true, timing=true); using Ray'
+RUN julia --project=${RAY_JL_PROJECT} -e 'using Pkg; Pkg.precompile(strict=true, timing=true); using Ray'
+
+# Add Ray.jl to the default Julia environment
+RUN JULIA_PROJECT="" julia -e 'using Pkg; Pkg.develop(path=ENV["RAY_JL_PROJECT"])'
 
 # Set up default project and working dir so that users need only pass in the requisite script input args
 WORKDIR ${RAY_JL_PROJECT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID
 # Overwrite the Overrides.toml created during Pkg.build
 COPY --chown=ray <<-EOF ${HOME}/.julia/artifacts/Overrides.toml
 [c348cde4-7f22-4730-83d8-6959fb7a17ba]
-ray_julia = "${RAY_JL_PROJECT}/ray_julia_jll/deps/bin"
+ray_julia = "${RAY_JLL_PROJECT}/deps/bin"
 EOF
 
 COPY --chown=ray . ${RAY_JL_PROJECT}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# Dockerfile is currently only for x86_64
 
 # TODO: Cleanup uid/gid/user work arounds
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,12 @@ ENV JULIA_PKG_USE_CLI_GIT="true"
 # path used during package precompilation matches the final depot path used in the image.
 # If a source file no longer resides at the expected location the `.ji` is deemed stale and
 # will be recreated.
-RUN ln -s /tmp/julia-cache ~/.julia
+ARG JULIA_DEPOT_CACHE=/tmp/julia-cache
+RUN ln -s ${JULIA_DEPOT_CACHE} ~/.julia
 
 # Install Julia package registries
-RUN --mount=type=cache,sharing=locked,target=/tmp/julia-cache,uid=${UID},gid=${GID} \
-    mkdir -p /tmp/julia-cache && \
+RUN --mount=type=cache,sharing=locked,target=${JULIA_DEPOT_CACHE},uid=${UID},gid=${GID} \
+    mkdir -p ${JULIA_DEPOT_CACHE} && \
     julia -e 'using Pkg; Pkg.Registry.add("General")'
 
 # Instantiate the Julia project environment
@@ -69,16 +70,16 @@ COPY --chown=ray *Project.toml *Manifest.toml ${JULIA_PROJECT}/
 RUN mkdir -p ${JULIA_PROJECT}/ray_julia_jll/src && touch ${JULIA_PROJECT}/ray_julia_jll/src/ray_julia_jll.jl
 
 # Note: The `timing` flag requires Julia 1.9
-RUN --mount=type=cache,sharing=locked,target=/tmp/julia-cache,uid=${UID},gid=${GID} \
+RUN --mount=type=cache,sharing=locked,target=${JULIA_DEPOT_CACHE},uid=${UID},gid=${GID} \
     julia -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile(strict=true, timing=true)'
 
 # Copy the shared ephemeral Julia depot into the image and remove any installed packages
 # not used by our Manifest.toml.
-RUN --mount=type=cache,target=/tmp/julia-cache,uid=${UID},gid=${GID} \
+RUN --mount=type=cache,target=${JULIA_DEPOT_CACHE},uid=${UID},gid=${GID} \
     rm ~/.julia && \
     mkdir ~/.julia && \
-    cp -rp /tmp/julia-cache/* ~/.julia && \
-    julia -e 'using Pkg, Dates; Pkg.gc(; collect_delay=Day(0))'
+    cp -rp ${JULIA_DEPOT_CACHE}/* ~/.julia && \
+    julia -e 'using Pkg, Dates; Pkg.gc(collect_delay=Day(0))'
 
 #####
 ##### ray-jl stage
@@ -87,6 +88,7 @@ RUN --mount=type=cache,target=/tmp/julia-cache,uid=${UID},gid=${GID} \
 FROM ray-base as ray-jl
 
 # Install Bazel and compilers
+ARG BAZEL_CACHE=/mnt/bazel-cache
 RUN set -eux; \
     case $(uname -m) in \
         "x86_64")  ARCH=amd64 ;; \
@@ -99,7 +101,7 @@ RUN set -eux; \
         --slave /usr/bin/gcov gcov /usr/bin/gcov-9 && \
     curl -sSLo bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-${ARCH} && \
     sudo install bazel /usr/local/bin && \
-    ln -s /mnt/bazel-cache ~/.cache/bazel
+    ln -s ${BAZEL_CACHE} ~/.cache/bazel
 
 # Install npm
 # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#preparing-to-build-ray-on-linux
@@ -118,12 +120,12 @@ RUN sudo mkdir -p ${JULIA_PROJECT} && \
 # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
 ARG RAY_ROOT=/ray
 ARG RAY_COMMIT=448a83caf4
-ARG RAY_GEN_CACHE_DIR=/mnt/ray-generated
+ARG RAY_REPO_CACHE=/mnt/ray-cache
 ARG RAY_CACHE_CLEAR=false
 RUN sudo mkdir -p ${RAY_ROOT} && \
     sudo chown ray ${RAY_ROOT}
-RUN --mount=type=cache,sharing=locked,target=/mnt/bazel-cache,uid=${UID},gid=${GID} \
-    --mount=type=cache,sharing=locked,target=${RAY_GEN_CACHE_DIR},uid=${UID},gid=${GID} \
+RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
+    --mount=type=cache,sharing=locked,target=${RAY_REPO_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
     git clone https://github.com/beacon-biosignals/ray ${RAY_ROOT} && \
     git -C ${RAY_ROOT} checkout ${RAY_COMMIT} && \
@@ -134,15 +136,15 @@ RUN --mount=type=cache,sharing=locked,target=/mnt/bazel-cache,uid=${UID},gid=${G
     # Allow builders to clear just the Ray CLI cache.
     if [ "${RAY_CACHE_CLEAR}" != "false" ]; then \
         bazel clean --expunge && \
-        rm -rf ${RAY_GEN_CACHE_DIR}/*; \
+        rm -rf ${RAY_REPO_CACHE}/*; \
     fi && \
     #
     # The Ray `BUILD.bazel` includes a bunch of `copy_to_workspace` rules which copy build output
     # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
     # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
     # saving/restoring these files we can work around this.
-    if [ -d ${RAY_GEN_CACHE_DIR}/.git ]; then \
-        cd ${RAY_GEN_CACHE_DIR} && \
+    if [ -d ${RAY_REPO_CACHE}/.git ]; then \
+        cd ${RAY_REPO_CACHE} && \
         cp -rp --parents \
             python/ray/_raylet.so \
             python/ray/core/generated \
@@ -164,8 +166,8 @@ RUN --mount=type=cache,sharing=locked,target=/mnt/bazel-cache,uid=${UID},gid=${G
     #
     # By copying the entire Ray worktree we can easily restore missing files without having to
     # delete the cache and build from scratch.
-    mkdir -p ${RAY_GEN_CACHE_DIR} && \
-    cp -rfp ${RAY_ROOT}/. ${RAY_GEN_CACHE_DIR} && \
+    mkdir -p ${RAY_REPO_CACHE} && \
+    cp -rfp ${RAY_ROOT}/. ${RAY_REPO_CACHE} && \
     #
     # Remove directory to avoid conflict with a future COPY
     rm -rf ${JLL_JULIA_PROJECT}
@@ -176,7 +178,7 @@ COPY --chown=ray --link --from=deps ${HOME}/.julia ${HOME}/.julia
 # Setup ray_julia_jll
 ARG JLL_ROOT=/ray_julia_jll
 COPY --chown=ray ray_julia_jll ${JLL_ROOT}
-RUN --mount=type=cache,sharing=locked,target=/mnt/bazel-cache,uid=${UID},gid=${GID} \
+RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
     ln -s ${RAY_ROOT} ${JLL_ROOT}/deps/ray && \
     ln -s ${JLL_ROOT} ${JLL_JULIA_PROJECT} && \


### PR DESCRIPTION
Did a bunch of refactoring as part of this. The main change here was installing the Ray.jl package in `~/.julia/dev/Ray` to make it easier to access from other images. Additionally, this Dockerfile doesn't rely on using `JULIA_PROJECT` and instead adds Ray.jl to the default Julia environment.