### PR TITLE
Use `cache-compiled` feature from `julia-actions/cache`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,10 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+        with:
+          cache-name: "${{ github.workflow }}-${{ github.job }}-${{ matrix.pkg.name }}-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}"
+          cache-compiled: true
+
       # TODO: We shouldn't require separate caches per Julia version but allow cache restores to work
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
       # https://github.com/beacon-biosignals/Ray.jl/issues/63

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -53,6 +53,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+        with:
+          cache-name: "${{ github.workflow }}-${{ github.job }}-${{ matrix.pkg.name }}-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}"
+          cache-compiled: true
 
       # TODO: We shouldn't require separate caches per Julia version but allow cache restores to work
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key


### PR DESCRIPTION
Uses a feature from this GitHub action to allow caching of Julia `.ji` files. Upstream issue: https://github.com/julia-actions/cache/issues/11