### PR TITLE
Use a separate project for `ray_julia_jll/deps`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,11 +112,6 @@ jobs:
           using Pkg
           Pkg.instantiate()
           include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
-
-          cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
-          [c348cde4-7f22-4730-83d8-6959fb7a17ba]
-          ray_julia = "$(pwd)/ray_julia_jll/deps/bazel-bin"
-          EOF
       - name: "Monorepo setup"
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
           - x64
     env:
       ray_julia_jll_dir: ./ray_julia_jll
+      build_dir: ./ray_julia_jll/deps
       ray_dir: ./ray_julia_jll/deps/ray
     steps:
       - uses: actions/checkout@v3
@@ -107,11 +108,12 @@ jobs:
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
-        shell: julia --color=yes --project=./ray_julia_jll/deps {0}
+        shell: julia --color=yes --project {0}
         run: |
           using Pkg
           Pkg.instantiate()
-          include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
+          include("build_jll.jl")
+        working-directory: ${{ env.build_dir }}
       - name: "Monorepo setup"
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           using Pkg
           Pkg.instantiate()
-          include("build_jll.jl")
+          include(joinpath(pwd(), "build_jll.jl"))
         working-directory: ${{ env.build_dir }}
       - name: "Monorepo setup"
         shell: julia --color=yes --project {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,11 +106,20 @@ jobs:
           mkdir -p "$RAY_GEN_CACHE_DIR"
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
+      - name: Build ray_julia library
+        shell: julia --color=yes --project=${{ env.ray_julia_jll_dir }}/deps {0}
+        run: |
+          using Pkg
+          Pkg.instantiate()
+          include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
+
+          cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
+          [c348cde4-7f22-4730-83d8-6959fb7a17ba]
+          ray_julia = "$(pwd)/ray_julia_jll/deps/bazel-bin"
+          EOF
       - name: "Monorepo setup"
         shell: julia --color=yes --project {0}
         run: |
-          overrides_toml = joinpath(first(Base.DEPOT_PATH), "artifacts", "Overrides.toml")
-          isfile(overrides_toml) && rm(overrides_toml)
           using Pkg
           Pkg.develop(PackageSpec(; path="${{ env.ray_julia_jll_dir }}"))
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,7 +107,7 @@ jobs:
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
-        shell: julia --color=yes --project=${{ env.ray_julia_jll_dir }}/deps {0}
+        shell: julia --color=yes --project=./ray_julia_jll/deps {0}
         run: |
           using Pkg
           Pkg.instantiate()

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -106,11 +106,6 @@ jobs:
           using Pkg
           Pkg.instantiate()
           include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
-
-          cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
-          [c348cde4-7f22-4730-83d8-6959fb7a17ba]
-          ray_julia = "$(pwd)/ray_julia_jll/deps/bazel-bin"
-          EOF
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ env.ray_julia_jll_dir }}

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -108,7 +108,7 @@ jobs:
           @show readdir()
           using Pkg
           Pkg.instantiate()
-          include("build_jll.jl")
+          include("${{ env.build_dir }}/build_jll.jl")
         working-directory: ${{ env.build_dir }}
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -108,7 +108,7 @@ jobs:
           @show readdir()
           using Pkg
           Pkg.instantiate()
-          include("${{ env.build_dir }}/build_jll.jl")
+          include(joinpath(pwd(), "build_jll.jl"))
         working-directory: ${{ env.build_dir }}
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -34,6 +34,7 @@ jobs:
           - x64
     env:
       ray_julia_jll_dir: ./ray_julia_jll
+      build_dir: ./ray_julia_jll/deps
       ray_dir: ./ray_julia_jll/deps/ray
     steps:
       - uses: actions/checkout@v3
@@ -101,11 +102,12 @@ jobs:
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
-        shell: julia --color=yes --project=./ray_julia_jll/deps {0}
+        shell: julia --color=yes --project {0}
         run: |
           using Pkg
           Pkg.instantiate()
-          include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
+          include("build_jll.jl")
+        working-directory: ${{ env.build_dir }}
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ env.ray_julia_jll_dir }}

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -101,7 +101,7 @@ jobs:
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
-        shell: julia --color=yes --project=${{ env.ray_julia_jll_dir }}/deps {0}
+        shell: julia --color=yes --project=./ray_julia_jll/deps {0}
         run: |
           using Pkg
           Pkg.instantiate()

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -100,12 +100,17 @@ jobs:
           mkdir -p "$RAY_GEN_CACHE_DIR"
           cp -rfp . "$RAY_GEN_CACHE_DIR"
         working-directory: ${{ env.ray_dir }}
-
-      - name: "JLL setup"
-        shell: julia --color=yes --project {0}
+      - name: Build ray_julia library
+        shell: julia --color=yes --project=${{ env.ray_julia_jll_dir }}/deps {0}
         run: |
-          overrides_toml = joinpath(first(Base.DEPOT_PATH), "artifacts", "Overrides.toml")
-          isfile(overrides_toml) && rm(overrides_toml)
+          using Pkg
+          Pkg.instantiate()
+          include("${{ env.ray_julia_jll_dir }}/deps/build_jll.jl")
+
+          cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
+          [c348cde4-7f22-4730-83d8-6959fb7a17ba]
+          ray_julia = "$(pwd)/ray_julia_jll/deps/bazel-bin"
+          EOF
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ env.ray_julia_jll_dir }}

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.8"  # Version used with MVP
+          # - "1.8"  # Version used with MVP
           - "1.9"  # Latest release
         os:
           - ubuntu-latest
@@ -58,52 +58,54 @@ jobs:
       # TODO: We shouldn't require separate caches per Julia version but allow cache restores to work
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
       # https://github.com/beacon-biosignals/Ray.jl/issues/63
-      - name: Restore build cache
-        uses: actions/cache/restore@v3
-        id: build-cache
-        with:
-          key: build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
-          path: ~/.cache
-          restore-keys: |
-            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
-            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
+      # - name: Restore build cache
+      #   uses: actions/cache/restore@v3
+      #   id: build-cache
+      #   with:
+      #     key: build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
+      #     path: ~/.cache
+      #     restore-keys: |
+      #       build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
+      #       build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
-      # Based upon:
-      # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
-      - name: Build Ray CLI
-        run: |
-          pip install --upgrade pip wheel
+      # # Based upon:
+      # # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
+      # - name: Build Ray CLI
+      #   run: |
+      #     pip install --upgrade pip wheel
 
-          # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
-          # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
-          # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
-          # saving/restoring these files we can work around this.
-          RAY_GEN_CACHE_DIR=~/.cache/ray-generated
-          if [ -d "$RAY_GEN_CACHE_DIR" ]; then
-              dest=$(pwd)
-              pushd $RAY_GEN_CACHE_DIR
-              cp -rp --parents \
-                  python/ray/_raylet.so \
-                  python/ray/core/generated \
-                  python/ray/serve/generated \
-                  python/ray/core/src/ray/raylet/raylet \
-                  python/ray/core/src/ray/gcs \
-                  $dest
-              popd
-          fi
+      #     # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
+      #     # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
+      #     # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
+      #     # saving/restoring these files we can work around this.
+      #     RAY_GEN_CACHE_DIR=~/.cache/ray-generated
+      #     if [ -d "$RAY_GEN_CACHE_DIR" ]; then
+      #         dest=$(pwd)
+      #         pushd $RAY_GEN_CACHE_DIR
+      #         cp -rp --parents \
+      #             python/ray/_raylet.so \
+      #             python/ray/core/generated \
+      #             python/ray/serve/generated \
+      #             python/ray/core/src/ray/raylet/raylet \
+      #             python/ray/core/src/ray/gcs \
+      #             $dest
+      #         popd
+      #     fi
 
-          pushd python
-          pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
-          popd
+      #     pushd python
+      #     pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
+      #     popd
 
-          # By copying the entire Ray worktree we can easily restore missing files without having to
-          # delete the cache and build from scratch.
-          mkdir -p "$RAY_GEN_CACHE_DIR"
-          cp -rfp . "$RAY_GEN_CACHE_DIR"
-        working-directory: ${{ env.ray_dir }}
+      #     # By copying the entire Ray worktree we can easily restore missing files without having to
+      #     # delete the cache and build from scratch.
+      #     mkdir -p "$RAY_GEN_CACHE_DIR"
+      #     cp -rfp . "$RAY_GEN_CACHE_DIR"
+      #   working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |
+          @show pwd()
+          @show readdir()
           using Pkg
           Pkg.instantiate()
           include("build_jll.jl")

--- a/.github/workflows/ray_julia_jll_CI.yml
+++ b/.github/workflows/ray_julia_jll_CI.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - "1.8"  # Version used with MVP
+          - "1.8"  # Version used with MVP
           - "1.9"  # Latest release
         os:
           - ubuntu-latest
@@ -58,54 +58,52 @@ jobs:
       # TODO: We shouldn't require separate caches per Julia version but allow cache restores to work
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
       # https://github.com/beacon-biosignals/Ray.jl/issues/63
-      # - name: Restore build cache
-      #   uses: actions/cache/restore@v3
-      #   id: build-cache
-      #   with:
-      #     key: build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
-      #     path: ~/.cache
-      #     restore-keys: |
-      #       build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
-      #       build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
+      - name: Restore build cache
+        uses: actions/cache/restore@v3
+        id: build-cache
+        with:
+          key: build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('deps/WORKSPACE.bazel.tpl', 'deps/BUILD.bazel') }}
+          path: ~/.cache
+          restore-keys: |
+            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
+            build-cache.ray_julia_jll-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
-      # # Based upon:
-      # # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
-      # - name: Build Ray CLI
-      #   run: |
-      #     pip install --upgrade pip wheel
+      # Based upon:
+      # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
+      - name: Build Ray CLI
+        run: |
+          pip install --upgrade pip wheel
 
-      #     # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
-      #     # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
-      #     # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
-      #     # saving/restoring these files we can work around this.
-      #     RAY_GEN_CACHE_DIR=~/.cache/ray-generated
-      #     if [ -d "$RAY_GEN_CACHE_DIR" ]; then
-      #         dest=$(pwd)
-      #         pushd $RAY_GEN_CACHE_DIR
-      #         cp -rp --parents \
-      #             python/ray/_raylet.so \
-      #             python/ray/core/generated \
-      #             python/ray/serve/generated \
-      #             python/ray/core/src/ray/raylet/raylet \
-      #             python/ray/core/src/ray/gcs \
-      #             $dest
-      #         popd
-      #     fi
+          # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
+          # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
+          # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
+          # saving/restoring these files we can work around this.
+          RAY_GEN_CACHE_DIR=~/.cache/ray-generated
+          if [ -d "$RAY_GEN_CACHE_DIR" ]; then
+              dest=$(pwd)
+              pushd $RAY_GEN_CACHE_DIR
+              cp -rp --parents \
+                  python/ray/_raylet.so \
+                  python/ray/core/generated \
+                  python/ray/serve/generated \
+                  python/ray/core/src/ray/raylet/raylet \
+                  python/ray/core/src/ray/gcs \
+                  $dest
+              popd
+          fi
 
-      #     pushd python
-      #     pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
-      #     popd
+          pushd python
+          pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
+          popd
 
-      #     # By copying the entire Ray worktree we can easily restore missing files without having to
-      #     # delete the cache and build from scratch.
-      #     mkdir -p "$RAY_GEN_CACHE_DIR"
-      #     cp -rfp . "$RAY_GEN_CACHE_DIR"
-      #   working-directory: ${{ env.ray_dir }}
+          # By copying the entire Ray worktree we can easily restore missing files without having to
+          # delete the cache and build from scratch.
+          mkdir -p "$RAY_GEN_CACHE_DIR"
+          cp -rfp . "$RAY_GEN_CACHE_DIR"
+        working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |
-          @show pwd()
-          @show readdir()
           using Pkg
           Pkg.instantiate()
           include(joinpath(pwd(), "build_jll.jl"))

--- a/README.md
+++ b/README.md
@@ -148,13 +148,12 @@ cd -
 
 ```sh
 source venv/bin/activate
-julia --project=ray_julia_jll/deps -e 'using Pkg; Pkg.instantiate(); include("ray_julia_jll/deps/build_jll.jl")'
+julia --project=ray_julia_jll/deps -e 'using Pkg; Pkg.instantiate()'
 
-cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
-[c348cde4-7f22-4730-83d8-6959fb7a17ba]
-ray_julia = "$(pwd)/ray_julia_jll/deps/bazel-bin"
-EOF
+# Adds an entry in "~/.julia/artifacts/Overrides.toml" unless `--no-override` is passed
+julia --project=ray_julia_jll/deps ray_julia_jll/deps/build_jll.jl
 
+# Use local "ray_julia_jll" when working on "Ray.jl"
 julia --project -e 'using Pkg; Pkg.develop(; path="./ray_julia_jll"); Pkg.instantiate()'
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cd -
 
 ```sh
 source venv/bin/activate
-julia --project=ray_julia_jll -e 'using Pkg; Pkg.instantiate(); include("ray_julia_jll/deps/build_jll.jl")'
+julia --project=ray_julia_jll/deps -e 'using Pkg; Pkg.instantiate(); include("ray_julia_jll/deps/build_jll.jl")'
 
 cat >> ~/.julia/artifacts/Overrides.toml <<-EOF
 [c348cde4-7f22-4730-83d8-6959fb7a17ba]

--- a/ray_julia_jll/Project.toml
+++ b/ray_julia_jll/Project.toml
@@ -6,16 +6,12 @@ version = "0.1.0"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 
 [compat]
 CxxWrap = "0.13.4"
 JSON3 = "1"
-Mustache = "1"
-TOML = "1"
 julia = "1.6"
 libcxxwrap_julia_jll = "0.9.7"
 

--- a/ray_julia_jll/deps/Project.toml
+++ b/ray_julia_jll/deps/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[compat]
+CxxWrap = "0.13.4"
+Mustache = "1"
+TOML = "1"
+julia = "1.6"

--- a/ray_julia_jll/deps/build_jll.jl
+++ b/ray_julia_jll/deps/build_jll.jl
@@ -34,7 +34,7 @@ if !isfile(joinpath(artifact_dir, library_name))
 end
 
 # Add entry to depot Overrides.toml
-if "--no-override" in ARGS
+if !("--no-override" in ARGS)
     overrides_toml = joinpath(first(DEPOT_PATH), "artifacts", "Overrides.toml")
     overrides_dict = isfile(overrides_toml) ? TOML.parsefile(overrides_toml) : Dict{String,Any}()
     overrides_dict[pkg_uuid] = Dict("ray_julia" => abspath(artifact_dir))

--- a/ray_julia_jll/deps/build_jll.jl
+++ b/ray_julia_jll/deps/build_jll.jl
@@ -32,3 +32,13 @@ end
 if !isfile(joinpath(artifact_dir, library_name))
     error("Failed to build library: $(joinpath(artifact_dir, library_name))")
 end
+
+# Add entry to depot Overrides.toml
+if "--no-override" in ARGS
+    overrides_toml = joinpath(first(DEPOT_PATH), "artifacts", "Overrides.toml")
+    overrides_dict = isfile(overrides_toml) ? TOML.parsefile(overrides_toml) : Dict{String,Any}()
+    overrides_dict[pkg_uuid] = Dict("ray_julia" => abspath(artifact_dir))
+    open(overrides_toml, "w") do io
+        TOML.print(io, overrides_dict)
+    end
+end


### PR DESCRIPTION
Doing this avoids having Ray.jl users take on additional dependencies only needed for building the package from source. With this change we're also no longer using the pre-built binaries in CI. I think we should probably have tests for both building from source or from pre-built binaries but that should be a separate job/workflow. I'll do that as a follow up PR.