### PR TITLE
Use fixed version of ray-project

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,17 +41,17 @@ jobs:
       ray_dir: ./build/ray
     steps:
       - uses: actions/checkout@v3
+      - name: Determine Ray commit
+        id: ray-commit
+        run: |
+           sha="$(cat build/ray_commit)"
+           echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
       - name: Clone Ray repository
         uses: actions/checkout@v3
         with:
           repository: beacon-biosignals/ray
           path: ${{ env.ray_dir }}
-      - name: Determine Ray commit
-        id: ray-commit
-        run: |
-           head_sha="$(git rev-parse HEAD)"
-           echo "head_sha=$head_sha" | tee -a "$GITHUB_OUTPUT"
-        working-directory: ${{ env.ray_dir }}
+          ref: ${{ steps.ray-commit.outputs.sha }}
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
@@ -68,10 +68,10 @@ jobs:
         uses: actions/cache/restore@v3
         id: build-cache
         with:
-          key: build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.hash-${{ hashFiles('ray_julia_jll/build/WORKSPACE.bazel.tpl', 'ray_julia_jll/build/BUILD.bazel') }}
+          key: build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.hash-${{ hashFiles('ray_julia_jll/build/WORKSPACE.bazel.tpl', 'ray_julia_jll/build/BUILD.bazel') }}
           path: ~/.cache
           restore-keys: |
-            build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.head_sha }}.
+            build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
       # Based upon:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Determine Ray commit
         id: ray-commit
         run: |
-           sha="$(cat build/ray_commit)"
-           echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
+          read -r sha < build/ray
+          echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
       - name: Clone Ray repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Determine Ray commit
         id: ray-commit
         run: |
-          read -r sha < build/ray
+          read -r sha < build/ray_commit
           echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
       - name: Clone Ray repository
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,12 +122,12 @@ ARG BUILD_PROJECT=${RAY_JL_PROJECT}/build
 ARG RAY_REPO=${HOME}/ray
 ARG RAY_REPO_CACHE=/mnt/ray-cache
 ARG RAY_CACHE_CLEAR=false
-COPY --chown=${UID} build/ray-commit /tmp/ray-commit
+COPY --chown=${UID} build/ray_commit /tmp/ray_commit
 RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     --mount=type=cache,sharing=locked,target=${RAY_REPO_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
     git clone https://github.com/beacon-biosignals/ray ${RAY_REPO} && \
-    git -C ${RAY_REPO} checkout $(cat /tmp/ray-commit) && \
+    git -C ${RAY_REPO} checkout $(cat /tmp/ray_commit) && \
     #
     # Build using the final Ray.jl destination
     mkdir -p ${BUILD_PROJECT} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,9 @@ COPY --chown=${UID} build/ray_commit /tmp/ray_commit
 RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     --mount=type=cache,sharing=locked,target=${RAY_REPO_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
+    read -r ray_commit < /tmp/ray_commit && \
     git clone https://github.com/beacon-biosignals/ray ${RAY_REPO} && \
-    git -C ${RAY_REPO} checkout $(cat /tmp/ray_commit) && \
+    git -C ${RAY_REPO} checkout ${ray_commit} && \
     #
     # Build using the final Ray.jl destination
     mkdir -p ${BUILD_PROJECT} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,14 +120,14 @@ ARG BUILD_PROJECT=${RAY_JL_PROJECT}/build
 # Install custom Ray CLI which supports the Julia language.
 # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
 ARG RAY_REPO=${HOME}/ray
-ARG RAY_COMMIT=448a83caf4
 ARG RAY_REPO_CACHE=/mnt/ray-cache
 ARG RAY_CACHE_CLEAR=false
+COPY --chown=${UID} build/ray-commit /tmp/ray-commit
 RUN --mount=type=cache,sharing=locked,target=${BAZEL_CACHE},uid=${UID},gid=${GID} \
     --mount=type=cache,sharing=locked,target=${RAY_REPO_CACHE},uid=${UID},gid=${GID} \
     set -eux && \
     git clone https://github.com/beacon-biosignals/ray ${RAY_REPO} && \
-    git -C ${RAY_REPO} checkout ${RAY_COMMIT} && \
+    git -C ${RAY_REPO} checkout $(cat /tmp/ray-commit) && \
     #
     # Build using the final Ray.jl destination
     mkdir -p ${BUILD_PROJECT} && \

--- a/build/build_library.jl
+++ b/build/build_library.jl
@@ -6,7 +6,7 @@ build_dir = @__DIR__()
 project_toml = joinpath(build_dir, "..", "Project.toml")
 artifact_dir = joinpath(build_dir, "bazel-bin")
 ray_dir = joinpath(build_dir, "ray")
-ray_commit = read(joinpath(build_dir, "ray_commit"), String)
+ray_commit = readchomp(joinpath(build_dir, "ray_commit"))
 library_name = "julia_core_worker_lib.so"
 
 dict = Dict(

--- a/build/build_library.jl
+++ b/build/build_library.jl
@@ -2,6 +2,8 @@ using CxxWrap
 using Mustache
 using TOML
 
+ray_commit = "448a83caf44108fc1bc44fa7c6c358cffcfcb0d7"
+
 build_dir = @__DIR__()
 project_toml = joinpath(build_dir, "..", "Project.toml")
 artifact_dir = joinpath(build_dir, "bazel-bin")
@@ -23,6 +25,12 @@ end
 # Clone "ray" repo when the directory is missing or empty
 isdir(ray_dir) && !isempty(readdir(ray_dir)) || cd(dirname(ray_dir)) do
     run(`git clone https://github.com/beacon-biosignals/ray $(basename(ray_dir))`)
+end
+
+# Ensure that library is always built against the same version of ray
+if !("--no-checkout" in ARGS)
+    run(`git -C $ray_dir fetch origin`)
+    run(`git -C $ray_dir checkout $ray_commit`)
 end
 
 cd(build_dir) do

--- a/build/build_library.jl
+++ b/build/build_library.jl
@@ -2,12 +2,11 @@ using CxxWrap
 using Mustache
 using TOML
 
-ray_commit = "448a83caf44108fc1bc44fa7c6c358cffcfcb0d7"
-
 build_dir = @__DIR__()
 project_toml = joinpath(build_dir, "..", "Project.toml")
 artifact_dir = joinpath(build_dir, "bazel-bin")
 ray_dir = joinpath(build_dir, "ray")
+ray_commit = read(joinpath(build_dir, "ray_commit"), String)
 library_name = "julia_core_worker_lib.so"
 
 dict = Dict(

--- a/build/ray_commit
+++ b/build/ray_commit
@@ -1,0 +1,1 @@
+448a83caf44108fc1bc44fa7c6c358cffcfcb0d7


### PR DESCRIPTION
In response to: https://github.com/beacon-biosignals/Ray.jl/pull/154#pullrequestreview-1649351425

By using a specific commit of `ray` in our `build_library.jl` script we can ensure that from source builds are full reproducible from any commit (from now on). We could just use the `WORKSPACE.bazel` to also do this but this allows us the flexibility to develop against a branch via `--no-checkout`