### PR TITLE
Fixes to build scripts for initial release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ venv
 # Ignore dependencies that are built
 build/WORKSPACE.bazel
 build/ray
-buid/bazel-*
+build/bazel-*
 build/tarballs

--- a/build/bind_artifacts.jl
+++ b/build/bind_artifacts.jl
@@ -7,8 +7,6 @@ using SHA: sha256
 using Tar
 using URIs: unescapeuri
 
-const DIR = mktempdir()
-
 include("common.jl")
 
 # Compute the Artifact.toml `git-tree-sha1`.
@@ -25,37 +23,23 @@ function sha256sum(tarball_path)
     end
 end
 
-function get_release_asset_urls()
-    io = IOBuffer()
-    Downloads.download(ASSETS_URL, io)
-    json = JSON3.read(String(take!(io)))
-    return unescapeuri.(get.(json[:assets], :browser_download_url))
-end
-
 if abspath(PROGRAM_FILE) == @__FILE__
-    @info "Fetching assets for $TAG"
-    artifacts_urls = get_release_asset_urls()
+    # Start with a clean Artifacts.toml so that unsupported platforms are removed
+    isfile(ARTIFACTS_TOML) && rm(ARTIFACTS_TOML)
 
-    for artifact_url in artifacts_urls
-        @info "Adding artifact for $(basename(artifact_url))"
-        artifact_path = joinpath(DIR, basename(artifact_url))
+    for platform in REQUIRED_PLATFORMS
+        artifact_name = gen_artifact_filename(; tag=TAG, platform)
+        artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename=artifact_name)
+
+        @info "Dowloading artifact $artifact_url"
+        artifact_path = joinpath(TARBALL_DIR, artifact_name)
         Downloads.download(artifact_url, artifact_path)
 
-        m = match(TARBALL_REGEX, basename(artifact_path))
-        if isnothing(m)
-            throw(ArgumentError("Could not parse host triplet from $(basename(artifact_path))"))
-        end
-
-        platform_triplet = m[:triplet]
-        julia_version = m[:julia_version]
-        platform_str = "$platform_triplet-julia_version+$julia_version"
-        platform = parse(BinaryPlatforms.Platform, platform_str)
-
-        bind_artifact!(JLL_ARTIFACTS_TOML,
+        @info "Adding artifact for $(triplet(platform))"
+        bind_artifact!(ARTIFACTS_TOML,
                        "ray_julia",
                        tree_hash_sha1(artifact_path);
                        platform=platform,
-                       download_info=[(artifact_url, sha256sum(artifact_path))],
-                       force=true)
+                       download_info=[(artifact_url, sha256sum(artifact_path))])
     end
 end

--- a/build/bind_artifacts.jl
+++ b/build/bind_artifacts.jl
@@ -29,7 +29,8 @@ if abspath(PROGRAM_FILE) == @__FILE__
 
     for platform in REQUIRED_PLATFORMS
         artifact_name = gen_artifact_filename(; tag=TAG, platform)
-        artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename=artifact_name)
+        artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG,
+                                        filename=artifact_name)
 
         @info "Dowloading artifact $artifact_url"
         artifact_path = joinpath(TARBALL_DIR, artifact_name)

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -1,4 +1,3 @@
-using Base: BinaryPlatforms
 using CodecZlib: GzipCompressorStream
 using Pkg
 using Tar: Tar
@@ -20,11 +19,10 @@ if abspath(PROGRAM_FILE) == @__FILE__
     @info "Building ray_julia library..."
     include("build_library.jl")
 
-    host_triplet = BinaryPlatforms.host_triplet()
-    tarball_name = "ray_julia.$TAG.$host_triplet.tar.gz"
+    host = supported_platform(HostPlatform())
+    tarball_name = gen_artifact_filename(; tag=TAG, platform=host)
 
     @info "Creating tarball $tarball_name"
-    compiled_dir = joinpath(REPO_PATH, "build", "bazel-bin")
     tarball_path = joinpath(TARBALL_DIR, tarball_name)
-    create_tarball(readlink(compiled_dir), tarball_path)
+    create_tarball(COMPILED_DIR, tarball_path)
 end

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -24,7 +24,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     tarball_name = "ray_julia.$TAG.$host_triplet.tar.gz"
 
     @info "Creating tarball $tarball_name"
-    compiled_dir = joinpath(REPO_PATH, "ray_julia_jll", "build", "bazel-bin")
+    compiled_dir = joinpath(REPO_PATH, "build", "bazel-bin")
     tarball_path = joinpath(TARBALL_DIR, tarball_name)
     create_tarball(readlink(compiled_dir), tarball_path)
 end

--- a/build/common.jl
+++ b/build/common.jl
@@ -23,7 +23,8 @@ const REQUIRED_JULIA_VERSIONS = (v"1.8", v"1.9")
 const REQUIRED_PLATFORMS = let
     base_platforms = parse.(Platform, REQUIRED_BASE_TRIPLETS)
     base_tags = [(; julia_version=string(v)) for v in REQUIRED_JULIA_VERSIONS]
-    [Platform(arch(p), platform_name(p); tags...) for p in base_platforms, tags in base_tags][:]
+    [Platform(arch(p), platform_name(p); tags...)
+     for p in base_platforms, tags in base_tags][:]
 end
 
 function remote_url(repo_root::AbstractString, name::AbstractString="origin")

--- a/build/common.jl
+++ b/build/common.jl
@@ -25,16 +25,15 @@ function remote_url(repo_root::AbstractString, name::AbstractString="origin")
     end
 end
 
-const REPO_PATH = abspath(joinpath(@__DIR__, "..", ".."))
+const REPO_PATH = abspath(joinpath(@__DIR__, ".."))
 const PKG_URL = remote_url(REPO_PATH)
 
 # Read Project.toml
-const JLL_PATH = joinpath(REPO_PATH, "ray_julia_jll")
-const JLL_PROJECT_TOML = joinpath(JLL_PATH, "Project.toml")
-const JLL_ARTIFACTS_TOML = joinpath(JLL_PATH, "Artifacts.toml")
+const PROJECT_TOML = joinpath(REPO_PATH, "Project.toml")
+const ARTIFACTS_TOML = joinpath(REPO_PATH, "Artifacts.toml")
 
-const JLL_PROJECT = read_project(JLL_PROJECT_TOML)
-const TAG = "v$(JLL_PROJECT.version)"
+const PROJECT = read_project(PROJECT_TOML)
+const TAG = "v$(PROJECT.version)"
 
 const GITHUB_URL = "https://api.github.com/repos"
 const _PKG = split(PKG_URL, ":")[2]

--- a/build/upload_tarballs.jl
+++ b/build/upload_tarballs.jl
@@ -63,8 +63,9 @@ if abspath(PROGRAM_FILE) == @__FILE__
 
     # check that contents are tarballs with correct filename
     for t in readdir(TARBALL_DIR)
-        !isnothing(match(TARBALL_REGEX, t)) || error("Unexpected file found: tarballs/$t")
-        contains(t, "ray_julia.$TAG") || error("Unexpected version: tarballs/$t")
+        m = match(TARBALL_REGEX, t)
+        !isnothing(m) || error("Unexpected file found: tarballs/$t")
+        "v$(m[:jll_version])" == TAG || error("Unexpected JLL version: tarballs/$t")
     end
 
     artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename="")

--- a/build/upload_tarballs.jl
+++ b/build/upload_tarballs.jl
@@ -64,6 +64,10 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # check that contents are tarballs with correct filename
     all(t -> !isnothing(match(TARBALL_REGEX, t)), readdir(TARBALL_DIR))
 
+    all(readdir(TARBALL_DIR)) do t
+        contains(t, "ray_julia.$TAG") || error("Stale tarball found: $t")
+    end
+
     artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename="")
     branch = LibGit2.with(LibGit2.branch, LibGit2.GitRepo(REPO_PATH))
 

--- a/build/upload_tarballs.jl
+++ b/build/upload_tarballs.jl
@@ -62,10 +62,9 @@ if abspath(PROGRAM_FILE) == @__FILE__
     !haskey(ENV, "GITHUB_TOKEN") && error("\"GITHUB_TOKEN\" environment variable required.")
 
     # check that contents are tarballs with correct filename
-    all(t -> !isnothing(match(TARBALL_REGEX, t)), readdir(TARBALL_DIR))
-
-    all(readdir(TARBALL_DIR)) do t
-        contains(t, "ray_julia.$TAG") || error("Stale tarball found: $t")
+    for t in readdir(TARBALL_DIR)
+        !isnothing(match(TARBALL_REGEX, t)) || error("Unexpected file found: tarballs/$t")
+        contains(t, "ray_julia.$TAG") || error("Unexpected version: tarballs/$t")
     end
 
     artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename="")

--- a/build/upload_tarballs.jl
+++ b/build/upload_tarballs.jl
@@ -3,42 +3,6 @@ using ghr_jll: ghr
 
 include("common.jl")
 
-# Parse "GIT URLs" syntax (URLs and a scp-like syntax). For details see:
-# https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a
-# Note that using a Regex like this is inherently insecure with regards to its
-# handling of passwords; we are unable to deterministically and securely erase
-# the passwords from memory after use.
-# TODO: reimplement with a Julian parser instead of leaning on this regex
-const URL_REGEX = r"""
-^(?:(?<scheme>ssh|git|https?)://)?+
-(?:
-    (?<user>.*?)
-    (?:\:(?<password>.*?))?@
-)?
-(?<host>[A-Za-z0-9\-\.]+)
-(?(<scheme>)
-    # Only parse port when not using scp-like syntax
-    (?:\:(?<port>\d+))?
-    /?
-    |
-    :?
-)
-(?<path>
-    # Require path to be preceded by '/'. Alternatively, ':' when using scp-like syntax.
-    (?<=(?(<scheme>)/|:))
-    .*
-)?
-$
-"""x
-
-function parse_git_remote_url(pkg_url)
-    m = match(URL_REGEX, pkg_url)
-    if m === nothing
-        throw(ArgumentError("Package URL is not a valid SCP or HTTP URL: $(pkg_url)"))
-    end
-    return "https://" * joinpath(m[:host], m[:path])
-end
-
 function upload_to_github_release(archive_path::AbstractString,
                                   archive_url::AbstractString,
                                   commit;
@@ -68,6 +32,7 @@ end
 
 function upload_to_github_release(owner, repo_name, commit, tag, path;
                                   token=ENV["GITHUB_TOKEN"])
+
     # Based on: https://github.com/JuliaPackaging/BinaryBuilder.jl/blob/d40ec617d131a1787851559ef1a9f04efce19f90/src/AutoBuild.jl#L487
     # TODO: Passing in a directory path uploads multiple assets
     # TODO: Would be nice to perform parallel uploads
@@ -82,7 +47,14 @@ function upload_to_github_release(owner, repo_name, commit, tag, path;
         $tag $path
     ```
 
-    return run(cmd)
+    try
+        run(cmd)
+    catch e
+        # ghr() already prints an error message with diagnosis
+        @debug "Caught exception $(sprint(showerror, e, catch_backtrace()))"
+    end
+
+    return nothing
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
@@ -92,15 +64,9 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # check that contents are tarballs with correct filename
     all(t -> !isnothing(match(TARBALL_REGEX, t)), readdir(TARBALL_DIR))
 
-    pkg_http_url = parse_git_remote_url(PKG_URL)
-    artifact_url = "$(pkg_http_url)/releases/download/$TAG"
+    artifact_url = gen_artifact_url(; repo_url=REPO_HTTPS_URL, tag=TAG, filename="")
     branch = LibGit2.with(LibGit2.branch, LibGit2.GitRepo(REPO_PATH))
 
     @info "Uploading tarballs to $artifact_url"
-    try
-        upload_to_github_release(TARBALL_DIR, artifact_url, branch)
-    catch e
-        # ghr() already prints an error message with diagnosis
-        @debug "Caught exception $(sprint(showerror, e, catch_backtrace()))"
-    end
+    upload_to_github_release(TARBALL_DIR, artifact_url, branch)
 end

--- a/docs/src/building-artifacts.md
+++ b/docs/src/building-artifacts.md
@@ -8,7 +8,7 @@ Follow [the instructions](https://github.com/beacon-biosignals/ray/blob/beacon-m
 
 ### Artifacts
 
-The `ray_julia` artifacts are hosted via [GitHub releases](https://github.com/beacon-biosignals/Ray.jl/releases) and will be downloaded automatically for any supported platform. To upate the artifacts, perform the following steps:
+The `ray_julia` artifacts are hosted via [GitHub releases](https://github.com/beacon-biosignals/Ray.jl/releases) and will be downloaded automatically for any supported platform. To update the artifacts, first ensure you have already [built Ray.jl](./developer-guide.md#build-rayjl) then perform the following steps:
 
 1. Update the Ray.jl version in the `Project.toml`
 

--- a/docs/src/building-artifacts.md
+++ b/docs/src/building-artifacts.md
@@ -14,7 +14,7 @@ The `ray_julia` artifacts are hosted via [GitHub releases](https://github.com/be
 
 2. Navigate to the `build` directory
 
-3. Run the `build_tarballs.jl` script to build the tarball for the host platform for the Julia version used. Builds are required for `Linux x86_64` and `macOS aarch64` on Julia `v1.8` and `v1.9`. It is advised you run this within the python virtual environment associated with the Ray.jl package to avoid unnecessary Bazel rebuilds.  Note: re-running this script _will overwrite_ an existing tarball for this version of Ray.jl.
+3. Run the `build_tarballs.jl` script to build the tarball for the host platform for the Julia version used. Builds are required for the platform triplets `x86_64-linux-gnu` and `aarch64-apple-darwin` on Julia `v1.8` and `v1.9`. It is advised you run this within the python virtual environment associated with the Ray.jl package to avoid unnecessary Bazel rebuilds.  Note: re-running this script _will overwrite_ an existing tarball for this version of Ray.jl.
 
    ```sh
    source ../venv/bin/activate


### PR DESCRIPTION
In attempting to do our initial release I encountered a few issues with things being out of date.

As I worked through these issues I noticed that the artifacts we are uploading have very specific triplets. Normally, the triplets from BinaryBuilder are based upon `BinaryBuilder.supported_platforms()` which uses quite generic triplets and mainly focuses on OS and architecture. Having an overly specific triplet is an issue in that it can result in us generating more artifacts than we have to. I've reduced the triplet down to what should be the current minimum. Ideally, we wouldn't use the Julia version in our triplet but appears that our `WORKSPACE.bazel` setup is pulling in Julia specific headers which is resulting in shared libraries which are incompatible with other Julia version (I think it's because our library is fully statically compiled).

Anyway, these should be the final changes needed to be merged so we can cut our initial release.