### PR TITLE
Add CI comment about tags ignoring paths

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
     paths:
       - "src/**"
       - "test/**"

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -1,5 +1,7 @@
 name: Dockerfile
 on:
+  push:
+    tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
   pull_request:
     paths:
       - "build/**"

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-    # Always run the Documenter workflow on tags, regardless of which paths have changed,
-    # to ensure we build the "stable" docs
-    tags: ["*"]
+    tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
+    paths:
+      - "docs/**"
+      - ".github/workflows/Documenter.yml"
   pull_request:
     paths:
       - "docs/**"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
     paths:
       - "**/*.jl"
       - ".github/workflows/FormatCheck.yml"

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
     paths:
       - "Artifacts.toml"
       - ".github/workflows/artifacts_CI.yml"


### PR DESCRIPTION
Follow up to #170. As it turns out when a workflow is triggered via a tag the `path` filter is ignored: https://github.com/orgs/community/discussions/26273.

The official documentation for this isn't clear at all and really it seems to be documented via omission. The only documentation on this I found was:

> If you define both `branches`/`branches-ignore` and `paths`/`paths-ignore`, the workflow will only run when both filters are satisfied

– https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

