### PR TITLE
Use default `versions` for `deploydocs`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,4 @@ makedocs(; modules=[Ray],
          pages)
 
 deploydocs(; repo="github.com/beacon-biosignals/Ray.jl.git", push_preview=true,
-           devbranch="main",
-           versions=["stable" => "Ray-v^", "Ray-v#.#",
-                     "dev" => "dev"])
+           devbranch="main")


### PR DESCRIPTION
The ["stable"](https://beacon-biosignals.github.io/Ray.jl/stable) documentation is still broken even after tagging `v0.0.1`. It looks like the culprit is the `versions` setting we had for [`deploydocs`](https://documenter.juliadocs.org/stable/lib/public/#Documenter.deploydocs). The default value for this function is `versions = ["stable" => "v^", "v#.#", "dev" => "dev"]`.

Unfortunately, the link will only be fixed when make a new tag.