### PR TITLE
Classify WORKSPACE.bazel.tpl as Mustache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Useful linguist links:
+# - https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
+# - https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml
+
+# Reclassifies `.tpl` files as Mustache templates
+*.tpl linguist-language=Mustache


### PR DESCRIPTION
Makes the `WORKSPACE.bazel.tpl` classified as a Mustache file instead of a Smarty file in the GItHub language breakdown.