### PR TITLE
Enable Apple silicon CI runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,11 @@ jobs:
           repository: beacon-biosignals/ray
           path: ${{ env.ray_dir }}
           ref: ${{ steps.ray-commit.outputs.sha }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ${{ env.ray_dir }}/python/setup.py
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,9 +137,11 @@ jobs:
           popd
 
           # By copying the entire Ray worktree we can easily restore missing files without having to
-          # delete the cache and build from scratch.
-          mkdir -p "$RAY_GEN_CACHE_DIR"
-          cp -rfp . "$RAY_GEN_CACHE_DIR"
+          # delete the cache and build from scratch. Skip copy when we don't save the cache.
+          if [ "${{ steps.build-cache.outputs.cache-hit }}" != "true" ]; then
+              mkdir -p "$RAY_GEN_CACHE_DIR"
+              cp -rfp . "$RAY_GEN_CACHE_DIR"
+          fi
 
           # Verify Ray CLI works
           echo "Verify Ray CLI works" >&2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,6 @@ jobs:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
       - name: Build Ray CLI
         run: |
-          set -eux
           pip install --upgrade pip wheel
 
           # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
@@ -94,7 +93,6 @@ jobs:
           RAY_GEN_CACHE_DIR=~/.cache/ray-generated
           if [ -d "$RAY_GEN_CACHE_DIR" ]; then
               dest_root=$(pwd)
-              pushd $RAY_GEN_CACHE_DIR
               rel_srcs=(
                   python/ray/_raylet.so \
                   python/ray/core/generated \
@@ -103,12 +101,16 @@ jobs:
                   python/ray/core/src/ray/gcs \
               )
               for rel in "${rel_srcs[@]}"; do
+                  echo "Restoring $rel" >&2
+                  src="$RAY_GEN_CACHE_DIR/$rel"
                   dest="$dest_root/$rel"
-                  echo "Restoring $rel"
                   mkdir -p $(dirname $dest)
-                  cp -rp $rel $dest
+                  cp -rp $src $dest
+                  echo "src:"
+                  ls -l $src
+                  echo "dest:"
+                  ls -l $dest
               done
-              popd
           fi
 
           pushd python
@@ -121,6 +123,7 @@ jobs:
           cp -rfp . "$RAY_GEN_CACHE_DIR"
 
           # Verify Ray CLI works
+          echo "Verify Ray CLI works" >&2
           ray --version
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,9 @@ jobs:
 
       - name: Show Cache
         run: |
-          [ -d ~/.cache ] && find ~/.cache
+          if [ -d ~/.cache ]
+              find ~/.cache
+          fi
 
       # Based upon:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,6 +118,9 @@ jobs:
           # delete the cache and build from scratch.
           mkdir -p "$RAY_GEN_CACHE_DIR"
           cp -rfp . "$RAY_GEN_CACHE_DIR"
+
+          # Verify Ray CLI works
+          ray --version
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,16 +136,6 @@ jobs:
 
           ls -l ~/.cache/bazel/_bazel_$USER
         working-directory: ${{ env.ray_dir }}
-      - name: Build Ray CLI 2
-        run: |
-          pushd python
-          pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
-          popd
-
-          # Verify Ray CLI works
-          echo "Verify Ray CLI works" >&2
-          ray --version
-        working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,12 +103,12 @@ jobs:
               for rel in "${rel_srcs[@]}"; do
                   echo "Restoring $rel" >&2
                   src="$RAY_GEN_CACHE_DIR/$rel"
-                  dest="$dest_root/$rel"
-                  mkdir -p $(dirname $dest)
+                  dest=$(dirname "$dest_root/$rel")
+                  mkdir -p $dest
                   cp -rp $src $dest
-                  echo "src:"
+                  echo "src: $src"
                   ls -l $src
-                  echo "dest:"
+                  echo "dest: $dest"
                   ls -l $dest
               done
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,20 +85,6 @@ jobs:
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
-      - name: Show Cache
-        run: |
-          echo "-----------"
-          echo "find -L ~/.cache"
-          if [ -d ~/.cache ]; then
-              find -L ~/.cache
-          fi
-
-          echo "-----------"
-          echo "find -L /private/var/tmp"
-          if [ -d /private/var/tmp ]; then
-              find -L /private/var/tmp
-          fi
-
       # Based upon:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
       - name: Build Ray CLI
@@ -152,19 +138,6 @@ jobs:
           echo "Verify Ray CLI works" >&2
           ray --version
         working-directory: ${{ env.ray_dir }}
-      - name: Show Cache After
-        run: |
-          echo "-----------"
-          echo "find -L ~/.cache"
-          if [ -d ~/.cache ]; then
-              find -L ~/.cache
-          fi
-
-          echo "-----------"
-          echo "find -L /private/var/tmp"
-          if [ -d /private/var/tmp ]; then
-              find -L /private/var/tmp
-          fi
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -123,6 +123,16 @@ jobs:
           echo "Verify Ray CLI works" >&2
           ray --version
         working-directory: ${{ env.ray_dir }}
+      - name: Build Ray CLI 2
+        run: |
+          pushd python
+          pip install . --verbose  # Fresh build takes ~50 minutes on basic GH runner
+          popd
+
+          # Verify Ray CLI works
+          echo "Verify Ray CLI works" >&2
+          ray --version
+        working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,15 +83,15 @@ jobs:
       - name: Show Cache
         run: |
           echo "-----------"
-          echo "find ~/.cache"
+          echo "find -L ~/.cache"
           if [ -d ~/.cache ]; then
-              find ~/.cache
+              find -L ~/.cache
           fi
 
           echo "-----------"
-          echo "find /private/var/tmp"
+          echo "find -L /private/var/tmp"
           if [ -d /private/var/tmp ]; then
-              find /private/var/tmp
+              find -L /private/var/tmp
           fi
 
       # Based upon:
@@ -147,15 +147,15 @@ jobs:
       - name: Show Cache After
         run: |
           echo "-----------"
-          echo "find ~/.cache"
+          echo "find -L ~/.cache"
           if [ -d ~/.cache ]; then
-              find ~/.cache
+              find -L ~/.cache
           fi
 
           echo "-----------"
-          echo "find /private/var/tmp"
+          echo "find -L /private/var/tmp"
           if [ -d /private/var/tmp ]; then
-              find /private/var/tmp
+              find -L /private/var/tmp
           fi
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Show Cache
         run: |
-          if [ -d ~/.cache ]
+          if [ -d ~/.cache ]; then
               find ~/.cache
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: build-cache
         with:
-          key: build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.hash-${{ hashFiles('ray_julia_jll/build/WORKSPACE.bazel.tpl', 'ray_julia_jll/build/BUILD.bazel') }}
+          key: build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.hash-${{ hashFiles('build/WORKSPACE.bazel.tpl', 'build/BUILD.bazel') }}
           path: ~/.cache
           restore-keys: |
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         version:
           - "1.8"  # Version used with MVP
-          # - "1.9"  # Latest release
+          - "1.9"  # Latest release
         os:
           - ubuntu-20.04-16core
           - macos-latest-xlarge  # Apple silicon

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,8 +102,9 @@ jobs:
 
           # Use `~/.cache/bazel` as the Bazel cache directory on macOS
           # https://bazel.build/remote/output-directories
-          if [ "$(uname -s)" = "Darwin" ]; then
+          if [ "$(uname -s)" = "Darwin" ] && [ ! -d ~/.cache/bazel ]; then
               mkdir -p ~/.cache/bazel/_bazel_$USER
+              rm -rf /private/var/tmp/_bazel_$USER
               ln -s ~/.cache/bazel/_bazel_$USER /private/var/tmp/_bazel_$USER
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         version:
           - "1.8"  # Version used with MVP
-          - "1.9"  # Latest release
+          # - "1.9"  # Latest release
         os:
           - ubuntu-20.04-16core
           - macos-latest-xlarge  # Apple silicon

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,8 +82,16 @@ jobs:
 
       - name: Show Cache
         run: |
+          echo "-----------"
+          echo "find ~/.cache"
           if [ -d ~/.cache ]; then
               find ~/.cache
+          fi
+
+          echo "-----------"
+          echo "find /private/var/tmp"
+          if [ -d /private/var/tmp ]; then
+              find /private/var/tmp
           fi
 
       # Based upon:
@@ -135,9 +143,20 @@ jobs:
           # Verify Ray CLI works
           echo "Verify Ray CLI works" >&2
           ray --version
-
-          ls -l ~/.cache/bazel/_bazel_$USER
         working-directory: ${{ env.ray_dir }}
+      - name: Show Cache After
+        run: |
+          echo "-----------"
+          echo "find ~/.cache"
+          if [ -d ~/.cache ]; then
+              find ~/.cache
+          fi
+
+          echo "-----------"
+          echo "find /private/var/tmp"
+          if [ -d /private/var/tmp ]; then
+              find /private/var/tmp
+          fi
       - name: Build ray_julia library
         shell: julia --color=yes --project {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
               )
               for rel in "${rel_srcs[@]}"; do
                   dest="$dest_root/$rel"
-                  echo "Restoring $rel -> $dest"
+                  echo "Restoring $rel"
                   mkdir -p $(dirname $dest)
                   cp -rp $rel $dest
               done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
           # saving/restoring these files we can work around this.
           RAY_GEN_CACHE_DIR=~/.cache/ray-generated
           if [ -d "$RAY_GEN_CACHE_DIR" ]; then
-              dest=$(pwd)
+              dest_root=$(pwd)
               pushd $RAY_GEN_CACHE_DIR
               rel_srcs=(
                   python/ray/_raylet.so \
@@ -101,10 +101,11 @@ jobs:
                   python/ray/core/src/ray/raylet/raylet \
                   python/ray/core/src/ray/gcs \
               )
-              for rel_src in "${rel_srcs[@]}"; do
-                  echo "Restoring $rel_src"
-                  mkdir -p $(dirname $rel_src)
-                  cp -rp $rel_src $dest/$rel_src
+              for rel in "${rel_srcs[@]}"; do
+                  dest="$dest_root/$rel"
+                  echo "Restoring $rel -> $dest"
+                  mkdir -p $(dirname $dest)
+                  cp -rp $rel $dest
               done
               popd
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Show Cache
         run: |
-          find ~/.cache
+          [ -d ~/.cache ] && find ~/.cache
 
       # Based upon:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,7 @@ jobs:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
       - name: Build Ray CLI
         run: |
+          set -eux
           pip install --upgrade pip wheel
 
           # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,24 +92,21 @@ jobs:
           # saving/restoring these files we can work around this.
           RAY_GEN_CACHE_DIR=~/.cache/ray-generated
           if [ -d "$RAY_GEN_CACHE_DIR" ]; then
-              dest_root=$(pwd)
-              rel_srcs=(
+              ray_repo=$(pwd)
+              srcs=(
                   python/ray/_raylet.so \
                   python/ray/core/generated \
                   python/ray/serve/generated \
                   python/ray/core/src/ray/raylet/raylet \
                   python/ray/core/src/ray/gcs \
               )
-              for rel in "${rel_srcs[@]}"; do
+              # Reimplemented `cp --parents` as this isn't supported by macOS
+              for rel in "${srcs[@]}"; do
                   echo "Restoring $rel" >&2
                   src="$RAY_GEN_CACHE_DIR/$rel"
-                  dest=$(dirname "$dest_root/$rel")
+                  dest=$(dirname "$ray_repo/$rel")
                   mkdir -p $dest
                   cp -rp $src $dest
-                  echo "src: $src"
-                  ls -l $src
-                  echo "dest: $dest"
-                  ls -l $dest
               done
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,13 +94,18 @@ jobs:
           if [ -d "$RAY_GEN_CACHE_DIR" ]; then
               dest=$(pwd)
               pushd $RAY_GEN_CACHE_DIR
-              cp -rp --parents \
+              rel_srcs=(
                   python/ray/_raylet.so \
                   python/ray/core/generated \
                   python/ray/serve/generated \
                   python/ray/core/src/ray/raylet/raylet \
                   python/ray/core/src/ray/gcs \
-                  $dest
+              )
+              for rel_src in "${rel_srcs[@]}"; do
+                  echo "Restoring $rel_src"
+                  mkdir -p $(dirname $rel_src)
+                  cp -rp $rel_src $dest/$rel_src
+              done
               popd
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,10 @@ jobs:
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.ray-${{ steps.ray-commit.outputs.sha }}.
             build-cache.ray-jl.${{ matrix.os }}.${{ matrix.arch }}.julia-${{ matrix.version }}.
 
+      - name: Show Cache
+        run: |
+          find ~/.cache
+
       # Based upon:
       # https://docs.ray.io/en/releases-2.5.1/ray-contribute/development.html#building-ray-on-linux-macos-full
       - name: Build Ray CLI

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,7 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ${ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,9 +32,16 @@ jobs:
           - "1.8"  # Version used with MVP
           - "1.9"  # Latest release
         os:
-          - ubuntu-latest
+          - ubuntu-20.04-16core
+          - macos-latest-xlarge  # Apple silicon
         arch:
           - x64
+          - aarch64
+        exclude:
+          - os: ubuntu-20.04-16core
+            arch: aarch64
+          - os: macos-latest-xlarge
+            arch: x64
     env:
       build_dir: ./build
       ray_dir: ./build/ray

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,6 +90,13 @@ jobs:
         run: |
           pip install --upgrade pip wheel
 
+          # Use `~/.cache/bazel` as the Bazel cache directory on macOS
+          # https://bazel.build/remote/output-directories
+          if [ "$(uname -s)" = "Darwin" ]; then
+              mkdir -p ~/.cache/bazel/_bazel_$USER
+              ln -s ~/.cache/bazel/_bazel_$USER /private/var/tmp/_bazel_$USER
+          fi
+
           # The Ray BUILD.bazel includes a bunch of `copy_to_workspace` rules which copy build output
           # into the Ray worktree. When we only restore the Bazel cache then re-building causes these
           # rules to be skipped resulting in `error: [Errno 2] No such file or directory`. By manually
@@ -126,6 +133,8 @@ jobs:
           # Verify Ray CLI works
           echo "Verify Ray CLI works" >&2
           ray --version
+
+          ls -l ~/.cache/bazel/_bazel_$USER
         working-directory: ${{ env.ray_dir }}
       - name: Build Ray CLI 2
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,9 +102,9 @@ jobs:
 
           # Use `~/.cache/bazel` as the Bazel cache directory on macOS
           # https://bazel.build/remote/output-directories
-          if [ "$(uname -s)" = "Darwin" ] && [ ! -d ~/.cache/bazel ]; then
+          if [ "$(uname -s)" = "Darwin" ]; then
               mkdir -p ~/.cache/bazel/_bazel_$USER
-              rm -rf /private/var/tmp/_bazel_$USER
+              rm -rf /private/var/tmp/_bazel_$USER  # Bazel cached data may be present from unrelated builds
               ln -s ~/.cache/bazel/_bazel_$USER /private/var/tmp/_bazel_$USER
           fi
 

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -2,12 +2,12 @@ name: Dockerfile
 on:
   push:
     tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
-  pull_request:
-    paths:
-      - "build/**"
-      - "Dockerfile"
-      - ".dockerignore"
-      - ".github/workflows/Dockerfile.yml"
+  # pull_request:
+  #   paths:
+  #     - "build/**"
+  #     - "Dockerfile"
+  #     - ".dockerignore"
+  #     - ".github/workflows/Dockerfile.yml"
 
 # Each PR and each commit on `main` use distinct concurrency groups. Note canceling workflows in
 # progress may result in having to rebuild layers as the Docker layer caching is only uploaded

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -19,8 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ubuntu-20.04-16core
     env:
       # Reference the HEAD commit which triggered this workflow. By default PRs use a merge commit
       SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -2,12 +2,12 @@ name: Dockerfile
 on:
   push:
     tags: ["*"]  # Triggers from tags ignore the `paths` filter: https://github.com/orgs/community/discussions/26273
-  # pull_request:
-  #   paths:
-  #     - "build/**"
-  #     - "Dockerfile"
-  #     - ".dockerignore"
-  #     - ".github/workflows/Dockerfile.yml"
+  pull_request:
+    paths:
+      - "build/**"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/Dockerfile.yml"
 
 # Each PR and each commit on `main` use distinct concurrency groups. Note canceling workflows in
 # progress may result in having to rebuild layers as the Docker layer caching is only uploaded

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -48,8 +48,16 @@ jobs:
         - name: Install Ray CLI
           run: |
             pip install --upgrade pip wheel
+            case $(uname -s) in
+                Linux)  OS=manylinux2014;;
+                Darwin) OS=macosx_13_0;;
+            esac
+            case $(uname -m) in
+                x86_64)  ARCH=x86_64;;
+                aarch64) ARCH=arm64;;
+            esac
             PYTHON=$(python3 --version | perl -ne '/(\d+)\.(\d+)/; print "cp$1$2-cp$1$2"')
-            pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-manylinux2014_x86_64.whl" "pydantic<2"
+            pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-${OS}_${ARCH}.whl" "pydantic<2"
         - name: Delete Overrides.toml
           shell: julia --color=yes --project {0}
           run: |

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -45,6 +45,9 @@ jobs:
             version: ${{ matrix.version }}
             arch: ${{ matrix.arch }}
         - uses: julia-actions/cache@v1
+        - uses: actions/setup-python@v4
+          with:
+            python-version: "3.10"
         - name: Install Ray CLI
           run: |
             pip install --upgrade pip wheel
@@ -54,10 +57,6 @@ jobs:
             esac
             ARCH=$(uname -m)
             PYTHON=$(python3 --version | perl -ne '/(\d+)\.(\d+)/; print "cp$1$2-cp$1$2"')
-            # TODO: Work around our ray release not having Python 3.11 support for macOS
-            if [ "$OS" = "macosx_13_0" ]; then
-                PYTHON=cp310-cp310
-            fi
             pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-${OS}_${ARCH}.whl" "pydantic<2"
         - name: Delete Overrides.toml
           shell: julia --color=yes --project {0}

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -52,10 +52,7 @@ jobs:
                 Linux)  OS=manylinux2014;;
                 Darwin) OS=macosx_13_0;;
             esac
-            case $(uname -m) in
-                x86_64)  ARCH=x86_64;;
-                aarch64) ARCH=arm64;;
-            esac
+            ARCH=$(uname -m)
             PYTHON=$(python3 --version | perl -ne '/(\d+)\.(\d+)/; print "cp$1$2-cp$1$2"')
             pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-${OS}_${ARCH}.whl" "pydantic<2"
         - name: Delete Overrides.toml

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -8,10 +8,10 @@ on:
     paths:
       - "Artifacts.toml"
       - ".github/workflows/artifacts_CI.yml"
-  # pull_request:
-  #   paths:
-  #     - "Artifacts.toml"
-  #     - ".github/workflows/artifacts_CI.yml"
+  pull_request:
+    paths:
+      - "Artifacts.toml"
+      - ".github/workflows/artifacts_CI.yml"
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -29,7 +29,7 @@ jobs:
           - "1.9"  # Latest release
         os:
           - ubuntu-20.04-16core
-          - macos-latest-xlarge  # M1
+          - macos-latest-xlarge  # Apple silicon
         arch:
           - x64
           - aarch64

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -20,8 +20,7 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ${ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,9 +28,16 @@ jobs:
           - "1.8"  # Version used with MVP
           - "1.9"  # Latest release
         os:
-          - ubuntu-latest
+          - ubuntu-20.04-16core
+          - macos-latest-xlarge  # M1
         arch:
           - x64
+          - aarch64
+        exclude:
+          - os: ubuntu-20.04-16core
+            arch: aarch64
+          - os: macos-latest-xlarge
+            arch: x64
     steps:
         - uses: actions/checkout@v3
         - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -8,10 +8,10 @@ on:
     paths:
       - "Artifacts.toml"
       - ".github/workflows/artifacts_CI.yml"
-  pull_request:
-    paths:
-      - "Artifacts.toml"
-      - ".github/workflows/artifacts_CI.yml"
+  # pull_request:
+  #   paths:
+  #     - "Artifacts.toml"
+  #     - ".github/workflows/artifacts_CI.yml"
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -54,6 +54,10 @@ jobs:
             esac
             ARCH=$(uname -m)
             PYTHON=$(python3 --version | perl -ne '/(\d+)\.(\d+)/; print "cp$1$2-cp$1$2"')
+            # TODO: Work around our ray release not having Python 3.11 support for macOS
+            if [ "$OS" = "macosx_13_0" ]; then
+                PYTHON=cp310-cp310
+            fi
             pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-${OS}_${ARCH}.whl" "pydantic<2"
         - name: Delete Overrides.toml
           shell: julia --color=yes --project {0}

--- a/.github/workflows/artifacts_CI.yml
+++ b/.github/workflows/artifacts_CI.yml
@@ -58,6 +58,9 @@ jobs:
             ARCH=$(uname -m)
             PYTHON=$(python3 --version | perl -ne '/(\d+)\.(\d+)/; print "cp$1$2-cp$1$2"')
             pip install -U "ray[default] @ https://github.com/beacon-biosignals/ray/releases/latest/download/ray-2.5.1-${PYTHON}-${OS}_${ARCH}.whl" "pydantic<2"
+
+            # Verify Ray CLI works
+            ray --version
         - name: Delete Overrides.toml
           shell: julia --color=yes --project {0}
           run: |


### PR DESCRIPTION
Using the newly announced M1 GHA runners: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/. We should test against M1 in CI as it's one of the very limited platforms we support for Ray.jl and doing this should unlock the ability for automated artifact builds for making new releases.

I did some initial non-cache timings as part of another PR: https://github.com/beacon-biosignals/Ray.jl/pull/178#issuecomment-1743567864