### PR TITLE
log unhandled metadata

### DIFF
--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -89,6 +89,7 @@ function deserialize_from_ray_object(x::SharedPtr{ray_jll.RayObject},
             @warn "Unhandled RayObject.Metadata: $(String(metadata_bytes))"
         end
     end
+
     bytes = take!(ray_jll.GetData(x[]))
     s = RaySerializer(IOBuffer(bytes))
     result = try

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -78,6 +78,15 @@ end
 
 function deserialize_from_ray_object(x::SharedPtr{ray_jll.RayObject},
                                      outer_object_ref=nothing)
+    # TODO: this is not right (some kind of weird nested ref/ptr business happening...)
+    metadata_ptr = ray_jll.GetMetadata(x[])[][]
+    if !isnull(metadata_ptr)
+        metadata_bytes = take!(metadata_ptr[])
+        if !isempty(metadata_bytes)
+            @warn "Unhandled RayObject.Metadata: $(String(metadata_bytes))"
+        end
+    end
+    
     bytes = take!(ray_jll.GetData(x[]))
     s = RaySerializer(IOBuffer(bytes))
     result = try

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -78,10 +78,13 @@ end
 
 function deserialize_from_ray_object(x::SharedPtr{ray_jll.RayObject},
                                      outer_object_ref=nothing)
-    # TODO: this is not right (some kind of weird nested ref/ptr business happening...)
-    metadata_ptr = ray_jll.GetMetadata(x[])[][]
-    if !isnull(metadata_ptr)
-        metadata_bytes = take!(metadata_ptr[])
+    # unlike CoreWorker::GetData, CoreWorker::GetMetadata returns a _reference_
+    # to a pointer to a buffer, so we need to dereference the return value to
+    # get the pointer that `take!` expects.
+    metadata_ptr = ray_jll.GetMetadata(x[])[]
+    # the pointer itself will not be null, but rather point to a null ref
+    if !isnull(metadata_ptr[])
+        metadata_bytes = take!(metadata_ptr)
         if !isempty(metadata_bytes)
             @warn "Unhandled RayObject.Metadata: $(String(metadata_bytes))"
         end

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -89,7 +89,6 @@ function deserialize_from_ray_object(x::SharedPtr{ray_jll.RayObject},
             @warn "Unhandled RayObject.Metadata: $(String(metadata_bytes))"
         end
     end
-    
     bytes = take!(ray_jll.GetData(x[]))
     s = RaySerializer(IOBuffer(bytes))
     result = try

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -83,7 +83,7 @@ end
         obj = Ray.serialize_to_ray_object([1, 2, 3])
 
         # make some metadata
-        metadata = "hello"
+        metadata = "hello\x00world"
         buffer = ray_jll.LocalMemoryBuffer(collect(codeunits(metadata)),
                                            length(metadata),
                                            true)
@@ -93,9 +93,9 @@ end
                                    StdVector{ray_jll.ObjectReference}(),
                                    false)
 
-        @test String(take!(ray_jll.GetMetadata(md_obj[])[])) == "hello"
+        @test String(take!(ray_jll.GetMetadata(md_obj[])[])) == "hello\x00world"
         @test_logs (:warn, r"Unhandled RayObject.Metadata: hello") begin
-            @test Ray.deserialize_from_ray_object(md_obj)) == [1, 2, 3]
+            @test Ray.deserialize_from_ray_object(md_obj) == [1, 2, 3]
         end
     end
 end

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -77,3 +77,23 @@ end
         @test deserialize(s) == x
     end
 end
+
+@testset "deserialize_from_ray_object" begin
+    @testset "metadata handling" begin
+        obj = Ray.serialize_to_ray_object([1, 2, 3])
+
+        # make some metadata
+        metadata = "hello"
+        buffer = ray_jll.LocalMemoryBuffer(collect(codeunits(metadata)),
+                                           length(metadata),
+                                           true)
+
+        md_obj = ray_jll.RayObject(ray_jll.GetData(obj[]),
+                                   buffer,
+                                   StdVector{ray_jll.ObjectReference}(),
+                                   false)
+
+        @test String(take!(ray_jll.GetMetadata(md_obj[])[])) == "hello"
+
+        Ray.deserialize_from_ray_object(md_obj)
+end

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -94,6 +94,7 @@ end
                                    false)
 
         @test String(take!(ray_jll.GetMetadata(md_obj[])[])) == "hello"
-
-        Ray.deserialize_from_ray_object(md_obj)
+        @test [1, 2, 3] == @test_logs((:warn, r"Unhandled RayObject.Metadata: hello"),
+                                      Ray.deserialize_from_ray_object(md_obj))
+    end
 end

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -94,7 +94,8 @@ end
                                    false)
 
         @test String(take!(ray_jll.GetMetadata(md_obj[])[])) == "hello"
-        @test [1, 2, 3] == @test_logs((:warn, r"Unhandled RayObject.Metadata: hello"),
-                                      Ray.deserialize_from_ray_object(md_obj))
+        @test_logs (:warn, r"Unhandled RayObject.Metadata: hello") begin
+            @test Ray.deserialize_from_ray_object(md_obj)) == [1, 2, 3]
+        end
     end
 end


### PR DESCRIPTION
This may help in debugging some of our sporadic task failures, where return objects do not deserialize correctly and which we suspect is due to un-handled metadata.

Eventually, in `deserialize_from_ray_object` we'll actually handle the known and relevant metadata cases, and this warning path will end up in a catchall `else` at the end.