### PR TITLE
Publish tarballs as pre-release assets in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           using Pkg
           Pkg.instantiate()
-          include(joinpath(pwd(), "build_tarballs.jl"))  # includes common.jl
+          include(joinpath(pwd(), "build_tarballs.jl"))
           open(ENV["GITHUB_OUTPUT"], "a") do io
               println(io, "tarball_path=$TARBALL_PATH")
               println(io, "tag=$TAG")

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Publish Pre-Release
         uses: softprops/action-gh-release@v1
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         with:
           prerelease: true
           generate_release_notes: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,11 +139,16 @@ jobs:
           ray --version
         working-directory: ${{ env.ray_dir }}
       - name: Build ray_julia library
+        id: ray_julia
         shell: julia --color=yes --project {0}
         run: |
           using Pkg
           Pkg.instantiate()
-          include(joinpath(pwd(), "build_library.jl"))
+          include(joinpath(pwd(), "build_tarballs.jl"))  # includes common.jl
+          open(ENV["GITHUB_OUTPUT"], "a") do io
+              println(io, "tarball_path=$TARBALL_PATH")
+              println(io, "tag=$TAG")
+          end
         working-directory: ${{ env.build_dir }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -163,3 +168,12 @@ jobs:
         with:
           key: ${{ steps.build-cache.outputs.cache-primary-key }}
           path: ~/.cache
+
+      - name: Publish Pre-Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          prerelease: true
+          generate_release_notes: true
+          tag_name: ${{ steps.ray_julia.outputs.tag }}
+          files: ${{ steps.ray_julia.outputs.tarball_path }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,6 +145,7 @@ jobs:
           using Pkg
           Pkg.instantiate()
           include(joinpath(pwd(), "build_tarballs.jl"))
+          build_host_tarball()
           open(ENV["GITHUB_OUTPUT"], "a") do io
               println(io, "tarball_path=$TARBALL_PATH")
               println(io, "tag=$TAG")

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ray"
 uuid = "3f779ece-f0b6-4c4f-a81a-0cb2add9eb95"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.0.1"
+version = "0.0.2-dev"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -13,14 +13,13 @@ function create_tarball(dir, tarball)
     end
 end
 
-
 function build_host_tarball()
     isdir(TARBALL_DIR) || mkdir(TARBALL_DIR)
 
     @info "Building ray_julia library..."
     include("build_library.jl")
 
-    @info "Creating tarball $tarball_name"
+    @info "Creating tarball $TARBALL_NAME"
     compiled_dir = readlink(joinpath(REPO_PATH, "build", "bazel-bin"))
     create_tarball(compiled_dir, TARBALL_PATH)
 end

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -20,5 +20,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
     include("build_library.jl")
 
     @info "Creating tarball $tarball_name"
-    create_tarball(COMPILED_DIR, TARBALL_PATH)
+    compiled_dir = readlink(joinpath(REPO_PATH, "build", "bazel-bin"))
+    create_tarball(compiled_dir, TARBALL_PATH)
 end

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -19,10 +19,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
     @info "Building ray_julia library..."
     include("build_library.jl")
 
-    host = supported_platform(HostPlatform())
-    tarball_name = gen_artifact_filename(; tag=TAG, platform=host)
-
     @info "Creating tarball $tarball_name"
-    tarball_path = joinpath(TARBALL_DIR, tarball_name)
-    create_tarball(COMPILED_DIR, tarball_path)
+    create_tarball(COMPILED_DIR, TARBALL_PATH)
 end

--- a/build/build_tarballs.jl
+++ b/build/build_tarballs.jl
@@ -13,7 +13,8 @@ function create_tarball(dir, tarball)
     end
 end
 
-if abspath(PROGRAM_FILE) == @__FILE__
+
+function build_host_tarball()
     isdir(TARBALL_DIR) || mkdir(TARBALL_DIR)
 
     @info "Building ray_julia library..."

--- a/build/common.jl
+++ b/build/common.jl
@@ -63,8 +63,6 @@ end
 
 const REPO_PATH = abspath(joinpath(@__DIR__, ".."))
 const REPO_HTTPS_URL = convert_to_https_url(remote_url(REPO_PATH))
-const COMPILED_DIR = readlink(joinpath(REPO_PATH, "build", "bazel-bin"))
-
 const ARTIFACTS_TOML = joinpath(REPO_PATH, "Artifacts.toml")
 
 const TAG = let

--- a/build/common.jl
+++ b/build/common.jl
@@ -2,7 +2,6 @@ using Base.BinaryPlatforms
 using LibGit2: LibGit2
 using Pkg.Types: read_project
 
-const TARBALL_DIR = joinpath(@__DIR__, "tarballs")
 const SO_FILE = "julia_core_worker_lib.so"
 
 const TARBALL_REGEX = r"""
@@ -73,3 +72,8 @@ const TAG = let
     project = read_project(project_toml)
     "v$(project.version)"
 end
+
+const HOST = supported_platform(HostPlatform())
+const TARBALL_DIR = joinpath(@__DIR__, "tarballs")
+const TARBALL_NAME = gen_artifact_filename(; tag=TAG, platform=HOST)
+const TARBALL_PATH = joinpath(TARBALL_DIR, TARBALL_NAME)


### PR DESCRIPTION
A necessary step towards https://github.com/orgs/beacon-biosignals/discussions/2379

With these changes we will no longer need `upload_tarballs.jl` and can remove steps 2-4 in the build steps.

Essentially the new workflow will boil down to: update the Project.toml, run `bind_artifacts.jl` and open a PR.

TODO (if we agree this is what we want):
- [ ] Delete `upload_tarballs.jl` (and modify `common.jl` etc accordingly)
- [ ] Modify `bind_artifacts.jl` to fetch assets from the _pre-release_ but commit the expected release url/tag
- [ ] Update build documentation

Can we run `bind_artifacts.jl` + commit as a git hook?