### PR TITLE
Add support converting wrapper enums to `Symbol`

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -497,18 +497,20 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("Hex", &ObjectID::Hex);
 
     // enum Language
-    mod.add_bits<ray::Language>("Language", jlcxx::julia_type("CppEnum"));
-    mod.set_const("PYTHON", ray::Language::PYTHON);
-    mod.set_const("JAVA", ray::Language::JAVA);
-    mod.set_const("CPP", ray::Language::CPP);
-    mod.set_const("JULIA", Language::JULIA);
+    // https://github.com/beacon-biosignals/ray/blob/ray-2.5.1%2B1/src/ray/protobuf/common.proto#L25
+    mod.add_bits<rpc::Language>("Language", jlcxx::julia_type("CppEnum"));
+    mod.set_const("PYTHON", rpc::Language::PYTHON);
+    mod.set_const("JAVA", rpc::Language::JAVA);
+    mod.set_const("CPP", rpc::Language::CPP);
+    mod.set_const("JULIA", rpc::Language::JULIA);
 
     // enum WorkerType
-    mod.add_bits<ray::core::WorkerType>("WorkerType", jlcxx::julia_type("CppEnum"));
-    mod.set_const("WORKER", ray::core::WorkerType::WORKER);
-    mod.set_const("DRIVER", ray::core::WorkerType::DRIVER);
-    mod.set_const("SPILL_WORKER", ray::core::WorkerType::SPILL_WORKER);
-    mod.set_const("RESTORE_WORKER", ray::core::WorkerType::RESTORE_WORKER);
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/protobuf/common.proto#L32
+    mod.add_bits<rpc::WorkerType>("WorkerType", jlcxx::julia_type("CppEnum"));
+    mod.set_const("WORKER", rpc::WorkerType::WORKER);
+    mod.set_const("DRIVER", rpc::WorkerType::DRIVER);
+    mod.set_const("SPILL_WORKER", rpc::WorkerType::SPILL_WORKER);
+    mod.set_const("RESTORE_WORKER", rpc::WorkerType::RESTORE_WORKER);
 
     // Needed by FunctionDescriptorInterface
     mod.add_bits<ray::rpc::FunctionDescriptor::FunctionDescriptorCase>("FunctionDescriptorCase");

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -36,9 +36,9 @@ const WORKER_TYPE_SYMBOLS = (:WORKER, :DRIVER, :SPILL_WORKER, :RESTORE_WORKER)
 # - A `Symbol` method allowing you convert a enum value to a `Symbol` (e.g. `Symbol(OK)`).
 # - A `instances` method allowing you to get a list of all enum values (e.g. `instances(StatusCode)`).
 @eval begin
-    $(_enum_expr(StatusCode, STATUS_CODE_SYMBOLS))
-    $(_enum_expr(Language, LANGUAGE_SYMBOLS))
-    $(_enum_expr(WorkerType, WORKER_TYPE_SYMBOLS))
+    $(_enum_expr(:StatusCode, STATUS_CODE_SYMBOLS))
+    $(_enum_expr(:Language, LANGUAGE_SYMBOLS))
+    $(_enum_expr(:WorkerType, WORKER_TYPE_SYMBOLS))
 end
 
 function check_status(status::Status)

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -33,16 +33,12 @@ const WORKER_TYPE_SYMBOLS = (:WORKER, :DRIVER, :SPILL_WORKER, :RESTORE_WORKER)
 
 # Generate the following methods for our wrapped enum types:
 # - A constructor allowing you to create a value via a `Symbol` (e.g. `StatusCode(:OK)`).
-# - A `instances` method allowing you to get a list of all enum values (e.g. `instances(StatusCode)`)
+# - A `Symbol` method allowing you convert a enum value to a `Symbol` (e.g. `Symbol(OK)`).
+# - A `instances` method allowing you to get a list of all enum values (e.g. `instances(StatusCode)`).
 @eval begin
-    $(_enum_symbol_constructor_expr(StatusCode, STATUS_CODE_SYMBOLS))
-    $(_enum_instances_expr(StatusCode, STATUS_CODE_SYMBOLS))
-
-    $(_enum_symbol_constructor_expr(Language, LANGUAGE_SYMBOLS))
-    $(_enum_instances_expr(Language, LANGUAGE_SYMBOLS))
-
-    $(_enum_symbol_constructor_expr(WorkerType, WORKER_TYPE_SYMBOLS))
-    $(_enum_instances_expr(WorkerType, WORKER_TYPE_SYMBOLS))
+    $(_enum_expr(StatusCode, STATUS_CODE_SYMBOLS))
+    $(_enum_expr(Language, LANGUAGE_SYMBOLS))
+    $(_enum_expr(WorkerType, WORKER_TYPE_SYMBOLS))
 end
 
 function check_status(status::Status)

--- a/src/ray_julia_jll/expr.jl
+++ b/src/ray_julia_jll/expr.jl
@@ -15,6 +15,26 @@ function _enum_symbol_constructor_expr(base_type::Type, members)
     end
 end
 
+function _enum_symbol_accessor_expr(base_type::Type, members)
+    base_type_sym = nameof(base_type)
+    body = Expr(:if, :(member === $(members[1])), QuoteNode(members[1]), nothing)
+    ex = body
+    for member in members[2:end]
+        ex.args[3] = Expr(:elseif, :(member === $member), QuoteNode(member), nothing)
+        ex = ex.args[3]
+    end
+    ex.args[3] = :(throw(ArgumentError("$($base_type_sym) has no member named: $member")))
+
+    base_type_sym = nameof(base_type)
+    members_tuple = Expr(:tuple, members...)
+
+    return quote
+        function Base.Symbol(member::$base_type)
+            return $body
+        end
+    end
+end
+
 function _enum_instances_expr(base_type::Type, members)
     base_type_sym = nameof(base_type)
     members_tuple = Expr(:tuple, members...)
@@ -26,18 +46,3 @@ function _enum_instances_expr(base_type::Type, members)
     end
 end
 
-# function Base.Symbol(language::Language)
-#     return if language === PYTHON
-#         :PYTHON
-#     elseif field === JAVA
-#         :JAVA
-#     elseif field === CPP
-#         :CPP
-#     elseif field === JULIA
-#         :JULIA
-#     else
-#         throw(ArgumentError("Unknown language: $language"))
-#     end
-# end
-
-# Base.instances(::Type{Language}) = (PYTHON, JAVA, CPP, JULIA)

--- a/src/ray_julia_jll/expr.jl
+++ b/src/ray_julia_jll/expr.jl
@@ -46,3 +46,10 @@ function _enum_instances_expr(base_type::Type, members)
     end
 end
 
+function _enum_expr(base_type::Type, members)
+    return quote
+        $(_enum_symbol_constructor_expr(base_type, members))
+        $(_enum_symbol_accessor_expr(base_type, members))
+        $(_enum_instances_expr(base_type, members))
+    end
+end

--- a/test/ray_julia_jll/expr.jl
+++ b/test/ray_julia_jll/expr.jl
@@ -1,3 +1,11 @@
+struct Fruit
+    val::UInt8
+end
+
+const APPLE = Fruit(0x01)
+const ORANGE = Fruit(0x02)
+const KIWI = Fruit(0x03)
+
 const FRUIT_SYMBOLS = (:APPLE, :ORANGE, :KIWI)
 
 @testset "_enum_symbol_constructor_expr" begin
@@ -20,6 +28,12 @@ const FRUIT_SYMBOLS = (:APPLE, :ORANGE, :KIWI)
     Base.remove_linenums!(expr)
     @test expr isa Expr
     @test expr == expected
+
+    @testset "evaluated" begin
+        eval(expr)
+        @test Fruit(:APPLE) == APPLE
+        @test_throws ArgumentError Fruit(:UNKNOWN)
+    end
 end
 
 @testset "_enum_symbol_accessor_expr" begin
@@ -42,6 +56,12 @@ end
     Base.remove_linenums!(expr)
     @test expr isa Expr
     @test expr == expected
+
+    @testset "evaluated" begin
+        eval(expr)
+        @test Symbol(APPLE) == :APPLE
+        @test_throws ArgumentError Symbol(Fruit(typemax(UInt8)))
+    end
 end
 
 @testset "_enum_instances_expr" begin
@@ -56,6 +76,11 @@ end
     Base.remove_linenums!(expr)
     @test expr isa Expr
     @test expr == expected
+
+    @testset "evaluated" begin
+        eval(expr)
+        @test instances(Fruit) == (APPLE, ORANGE, KIWI)
+    end
 end
 
 @testset "_enum_expr" begin

--- a/test/ray_julia_jll/expr.jl
+++ b/test/ray_julia_jll/expr.jl
@@ -1,0 +1,73 @@
+const FRUIT_SYMBOLS = (:APPLE, :ORANGE, :KIWI)
+
+@testset "_enum_symbol_constructor_expr" begin
+    expected = quote
+        function Fruit(member::Symbol)
+            return if member === :APPLE
+                APPLE
+            elseif member === :ORANGE
+                ORANGE
+            elseif member === :KIWI
+                KIWI
+            else
+                throw(ArgumentError("$(Fruit) has no member named: $(member)"))
+            end
+        end
+    end
+    Base.remove_linenums!(expected)
+
+    expr = ray_julia_jll._enum_symbol_constructor_expr(:Fruit, FRUIT_SYMBOLS)
+    Base.remove_linenums!(expr)
+    @test expr isa Expr
+    @test expr == expected
+end
+
+@testset "_enum_symbol_accessor_expr" begin
+    expected = quote
+        function Base.Symbol(member::Fruit)
+            return if member === APPLE
+                :APPLE
+            elseif member === ORANGE
+                :ORANGE
+            elseif member === KIWI
+                :KIWI
+            else
+                throw(ArgumentError("$(Fruit) has no member named: $(member)"))
+            end
+        end
+    end
+    Base.remove_linenums!(expected)
+
+    expr = ray_julia_jll._enum_symbol_accessor_expr(:Fruit, FRUIT_SYMBOLS)
+    Base.remove_linenums!(expr)
+    @test expr isa Expr
+    @test expr == expected
+end
+
+@testset "_enum_instances_expr" begin
+    expected = quote
+        function Base.instances(::Type{Fruit})
+            return (APPLE, ORANGE, KIWI)
+        end
+    end
+    Base.remove_linenums!(expected)
+
+    expr = ray_julia_jll._enum_instances_expr(:Fruit, FRUIT_SYMBOLS)
+    Base.remove_linenums!(expr)
+    @test expr isa Expr
+    @test expr == expected
+end
+
+@testset "_enum_expr" begin
+    expected = quote
+        $(ray_julia_jll._enum_symbol_constructor_expr(:Fruit, FRUIT_SYMBOLS))
+        $(ray_julia_jll._enum_symbol_accessor_expr(:Fruit, FRUIT_SYMBOLS))
+        $(ray_julia_jll._enum_instances_expr(:Fruit, FRUIT_SYMBOLS))
+    end
+    Base.remove_linenums!(expected)
+
+    expr = ray_julia_jll._enum_expr(:Fruit, FRUIT_SYMBOLS)
+    Base.remove_linenums!(expr)
+    @test expr isa Expr
+    @test expr == expected
+end

--- a/test/ray_julia_jll/runtests.jl
+++ b/test/ray_julia_jll/runtests.jl
@@ -11,6 +11,7 @@ f(x) = x + 1
 end
 
 @testset "ray_julia_jll.jl" begin
+    include("expr.jl")
     include("buffer.jl")
     include("function_descriptor.jl")
     include("address.jl")


### PR DESCRIPTION
Split out from #184. Changes include:

- Be clearer in our `wrapper.cc` file where the enums come from (protobuf)
- Add `_enum_symbol_accessor_expr` function which generates `Symbol(::$Enum)` methods
- Make it easier to add all of the various helper enum methods
- Add tests for all of the `_enum_*` functions. This required introducing more `:block` expressions so that the expected expressions matched the generated ones.