### PR TITLE
Wrap `ErrorType` enum

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -512,6 +512,34 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     mod.set_const("SPILL_WORKER", rpc::WorkerType::SPILL_WORKER);
     mod.set_const("RESTORE_WORKER", rpc::WorkerType::RESTORE_WORKER);
 
+    // enum ErrorType
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/protobuf/common.proto#L142
+    mod.add_bits<rpc::ErrorType>("ErrorType", jlcxx::julia_type("CppEnum"));
+    mod.set_const("WORKER_DIED", rpc::ErrorType::WORKER_DIED);
+    mod.set_const("ACTOR_DIED", rpc::ErrorType::ACTOR_DIED);
+    mod.set_const("OBJECT_UNRECONSTRUCTABLE", rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE);
+    mod.set_const("TASK_EXECUTION_EXCEPTION", rpc::ErrorType::TASK_EXECUTION_EXCEPTION);
+    mod.set_const("OBJECT_IN_PLASMA", rpc::ErrorType::OBJECT_IN_PLASMA);
+    mod.set_const("TASK_CANCELLED", rpc::ErrorType::TASK_CANCELLED);
+    mod.set_const("ACTOR_CREATION_FAILED", rpc::ErrorType::ACTOR_CREATION_FAILED);
+    mod.set_const("RUNTIME_ENV_SETUP_FAILED", rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED);
+    mod.set_const("OBJECT_LOST", rpc::ErrorType::OBJECT_LOST);
+    mod.set_const("OWNER_DIED", rpc::ErrorType::OWNER_DIED);
+    mod.set_const("OBJECT_DELETED", rpc::ErrorType::OBJECT_DELETED);
+    mod.set_const("DEPENDENCY_RESOLUTION_FAILED", rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED);
+    mod.set_const("OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED", rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED);
+    mod.set_const("OBJECT_UNRECONSTRUCTABLE_LINEAGE_EVICTED", rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_LINEAGE_EVICTED);
+    mod.set_const("OBJECT_FETCH_TIMED_OUT", rpc::ErrorType::OBJECT_FETCH_TIMED_OUT);
+    mod.set_const("LOCAL_RAYLET_DIED", rpc::ErrorType::LOCAL_RAYLET_DIED);
+    mod.set_const("TASK_PLACEMENT_GROUP_REMOVED", rpc::ErrorType::TASK_PLACEMENT_GROUP_REMOVED);
+    mod.set_const("ACTOR_PLACEMENT_GROUP_REMOVED", rpc::ErrorType::ACTOR_PLACEMENT_GROUP_REMOVED);
+    mod.set_const("TASK_UNSCHEDULABLE_ERROR", rpc::ErrorType::TASK_UNSCHEDULABLE_ERROR);
+    mod.set_const("ACTOR_UNSCHEDULABLE_ERROR", rpc::ErrorType::ACTOR_UNSCHEDULABLE_ERROR);
+    mod.set_const("OUT_OF_DISK_ERROR", rpc::ErrorType::OUT_OF_DISK_ERROR);
+    mod.set_const("OBJECT_FREED", rpc::ErrorType::OBJECT_FREED);
+    mod.set_const("OUT_OF_MEMORY", rpc::ErrorType::OUT_OF_MEMORY);
+    mod.set_const("NODE_DIED", rpc::ErrorType::NODE_DIED);
+
     // Needed by FunctionDescriptorInterface
     mod.add_bits<ray::rpc::FunctionDescriptor::FunctionDescriptorCase>("FunctionDescriptorCase");
 

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -31,6 +31,31 @@ const STATUS_CODE_SYMBOLS = (:OK,
 const LANGUAGE_SYMBOLS = (:PYTHON, :JAVA, :CPP, :JULIA)
 const WORKER_TYPE_SYMBOLS = (:WORKER, :DRIVER, :SPILL_WORKER, :RESTORE_WORKER)
 
+const ERROR_TYPE_SYMBOLS = (:WORKER_DIED,
+                            :ACTOR_DIED,
+                            :OBJECT_UNRECONSTRUCTABLE,
+                            :TASK_EXECUTION_EXCEPTION,
+                            :OBJECT_IN_PLASMA,
+                            :TASK_CANCELLED,
+                            :ACTOR_CREATION_FAILED,
+                            :RUNTIME_ENV_SETUP_FAILED,
+                            :OBJECT_LOST,
+                            :OWNER_DIED,
+                            :OBJECT_DELETED,
+                            :DEPENDENCY_RESOLUTION_FAILED,
+                            :OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED,
+                            :OBJECT_UNRECONSTRUCTABLE_LINEAGE_EVICTED,
+                            :OBJECT_FETCH_TIMED_OUT,
+                            :LOCAL_RAYLET_DIED,
+                            :TASK_PLACEMENT_GROUP_REMOVED,
+                            :ACTOR_PLACEMENT_GROUP_REMOVED,
+                            :TASK_UNSCHEDULABLE_ERROR,
+                            :ACTOR_UNSCHEDULABLE_ERROR,
+                            :OUT_OF_DISK_ERROR,
+                            :OBJECT_FREED,
+                            :OUT_OF_MEMORY,
+                            :NODE_DIED)
+
 # Generate the following methods for our wrapped enum types:
 # - A constructor allowing you to create a value via a `Symbol` (e.g. `StatusCode(:OK)`).
 # - A `Symbol` method allowing you convert a enum value to a `Symbol` (e.g. `Symbol(OK)`).
@@ -39,6 +64,7 @@ const WORKER_TYPE_SYMBOLS = (:WORKER, :DRIVER, :SPILL_WORKER, :RESTORE_WORKER)
     $(_enum_expr(:StatusCode, STATUS_CODE_SYMBOLS))
     $(_enum_expr(:Language, LANGUAGE_SYMBOLS))
     $(_enum_expr(:WorkerType, WORKER_TYPE_SYMBOLS))
+    $(_enum_expr(:ErrorType, ERROR_TYPE_SYMBOLS))
 end
 
 function check_status(status::Status)


### PR DESCRIPTION
Split out from #184. This enum is needed to identify and handle errors from the raylet which are in the ray object. [Example of how these are used in Python](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/serialization.py#L289-L364).

Depends on #186.