### PR TITLE
Raise error when encountering unhandled metadata

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -618,7 +618,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
                 nested_ids.push_back(ObjectID::FromBinary(ref.object_id()));
             }
             return nested_ids;
-        });
+        })
+        .method("HasData", &RayObject::HasData)
+        .method("HasMetadata", &RayObject::HasMetadata);
 
     // Julia RayObject constructors make shared_ptrs
     mod.method("RayObject", [] (

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -187,26 +187,27 @@ Base.hash(x::ObjectID, h::UInt) = hash(ObjectID, hash(Hex(x), h))
 ##### RayObject
 #####
 
-# Inspired by `RayObjectsToDataMetadataPairs`:
+# Functions `get_data` and `get_metadata` inspired by `RayObjectsToDataMetadataPairs`:
 # https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L458-L475
-function get_data_metadata(ray_obj_ptr::SharedPtr{RayObject})
-    ray_obj = ray_obj_ptr[]
 
-    data = if HasData(ray_obj)
+function get_data(ptr::SharedPtr{RayObject})
+    ray_obj = ptr[]
+    return if HasData(ray_obj)
         take!(GetData(ray_obj))
     else
         nothing
     end
+end
 
-    metadata = if HasMetadata(ray_obj)
+function get_metadata(ptr::SharedPtr{RayObject})
+    ray_obj = ptr[]
+    return if HasMetadata(ray_obj)
         # Unlike `GetData`, `GetMetadata` returns a _reference_ to a pointer to a buffer, so
         # we need to dereference the return value to get the pointer that `take!` expects.
         take!(GetMetadata(ray_obj)[])
     else
         nothing
     end
-
-    return (data, metadata)
 end
 
 #####

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -184,6 +184,30 @@ end
 Base.hash(x::ObjectID, h::UInt) = hash(ObjectID, hash(Hex(x), h))
 
 #####
+##### RayObject
+#####
+
+# Inspired by `RayObjectsToDataMetadataPairs`:
+# https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L458-L475
+function get_data_metadata(ray_obj::SharedPtr{RayObject})
+    data = if HasData(ray_obj[])
+        take!(GetData(ray_obj[]))
+    else
+        nothing
+    end
+
+    metadata = if HasMetadata(ray_obj[])
+        # Unlike `GetData`, `GetMetadata` returns a _reference_ to a pointer to a buffer, so
+        # we need to dereference the return value to get the pointer that `take!` expects.
+        take!(GetMetadata(ray_obj[])[])
+    else
+        nothing
+    end
+
+    return (data, metadata)
+end
+
+#####
 ##### TaskArg
 #####
 

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -189,17 +189,19 @@ Base.hash(x::ObjectID, h::UInt) = hash(ObjectID, hash(Hex(x), h))
 
 # Inspired by `RayObjectsToDataMetadataPairs`:
 # https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L458-L475
-function get_data_metadata(ray_obj::SharedPtr{RayObject})
-    data = if HasData(ray_obj[])
-        take!(GetData(ray_obj[]))
+function get_data_metadata(ray_obj_ptr::SharedPtr{RayObject})
+    ray_obj = ray_obj_ptr[]
+
+    data = if HasData(ray_obj)
+        take!(GetData(ray_obj))
     else
         nothing
     end
 
-    metadata = if HasMetadata(ray_obj[])
+    metadata = if HasMetadata(ray_obj)
         # Unlike `GetData`, `GetMetadata` returns a _reference_ to a pointer to a buffer, so
         # we need to dereference the return value to get the pointer that `take!` expects.
-        take!(GetMetadata(ray_obj[])[])
+        take!(GetMetadata(ray_obj)[])
     else
         nothing
     end

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -52,20 +52,25 @@ function serialize_to_bytes(x)
     return bytes
 end
 
-function serialize_to_ray_object(x)
+function serialize_to_ray_object(data, metadata=nothing)
     bytes = Vector{UInt8}()
     s = RaySerializer(bytes)
     writeheader(s)
-    serialize(s, x)
+    serialize(s, data)
+    data_buf = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
 
-    buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
-    metadata = ray_jll.NullPtr(ray_jll.Buffer)
+    metadata_buf = if !isnothing(metadata)
+        ray_jll.LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+    else
+        ray_jll.NullPtr(ray_jll.Buffer)
+    end
+
     inlined_ids = StdVector(collect(s.object_ids))::StdVector{ray_jll.ObjectID}
     worker = ray_jll.GetCoreWorker()
     inlined_refs = ray_jll.GetObjectRefs(worker, inlined_ids)
 
-    # this is actually a `std::shared_pointer<RayObject>`
-    return ray_jll.RayObject(buffer, metadata, inlined_refs, false)
+    # This is actually a `SharedPtr{RayObject}`
+    return ray_jll.RayObject(data_buf, metadata_buf, inlined_refs, false)
 end
 
 deserialize_from_bytes(bytes::Vector{UInt8}) = deserialize(Serializer(IOBuffer(bytes)))

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -86,7 +86,7 @@ function deserialize_from_ray_object(ray_obj::SharedPtr{ray_jll.RayObject},
                                      outer_object_ref=nothing)
     metadata = ray_jll.get_metadata(ray_obj)
     if !isnothing(metadata)
-        from = isnothing(outer_object_ref) ? "" : "from `$(repr(outer_object_ref))`"
+        from = isnothing(outer_object_ref) ? "" : " from `$(repr(outer_object_ref))`"
         error("Encountered unhandled metadata$from: $(String(metadata))")
     end
 

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -84,7 +84,6 @@ end
 
 function deserialize_from_ray_object(ray_obj::SharedPtr{ray_jll.RayObject},
                                      outer_object_ref=nothing)
-
     metadata = ray_jll.get_metadata(ray_obj)
     if !isnothing(metadata)
         from = isnothing(outer_object_ref) ? "" : "from `$(repr(outer_object_ref))`"

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -85,13 +85,13 @@ end
 function deserialize_from_ray_object(ray_obj::SharedPtr{ray_jll.RayObject},
                                      outer_object_ref=nothing)
 
-    data, metadata = ray_jll.get_data_metadata(ray_obj)
-
+    metadata = ray_jll.get_metadata(ray_obj)
     if !isnothing(metadata)
         from = isnothing(outer_object_ref) ? "" : "from `$(repr(outer_object_ref))`"
         error("Encountered unhandled metadata$from: $(String(metadata))")
     end
 
+    data = ray_jll.get_data(ray_obj)
     s = RaySerializer(IOBuffer(data))
     result = try
         deserialize(s)

--- a/test/ray_julia_jll/ray_object.jl
+++ b/test/ray_julia_jll/ray_object.jl
@@ -1,14 +1,16 @@
 using .ray_julia_jll: Buffer, LocalMemoryBuffer, NullPtr, ObjectReference, RayObject,
                       get_data, get_metadata
 
+local_buffer(x) = LocalMemoryBuffer(Ptr{Nothing}(pointer(x)), sizeof(x), true)
+
 @testset "RayObject" begin
     @testset "get_data / get_metadata" begin
         @testset "non-null data/metadata" begin
             data = UInt16[1:3;]
             metadata = b"22"
 
-            data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-            metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+            data_buf = local_buffer(data)
+            metadata_buf = local_buffer(metadata)
             nested_refs = StdVector{ObjectReference}()
             ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
 
@@ -25,7 +27,7 @@ using .ray_julia_jll: Buffer, LocalMemoryBuffer, NullPtr, ObjectReference, RayOb
             metadata = b"22"
 
             data_buf = NullPtr(Buffer)
-            metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+            metadata_buf = local_buffer(metadata)
             nested_refs = StdVector{ObjectReference}()
             ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
 
@@ -36,7 +38,7 @@ using .ray_julia_jll: Buffer, LocalMemoryBuffer, NullPtr, ObjectReference, RayOb
         @testset "null metadata" begin
             data = UInt16[1:3;]
 
-            data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+            data_buf = local_buffer(data)
             metadata_buf = NullPtr(Buffer)
             nested_refs = StdVector{ObjectReference}()
             ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)

--- a/test/ray_julia_jll/ray_object.jl
+++ b/test/ray_julia_jll/ray_object.jl
@@ -1,0 +1,18 @@
+using .ray_julia_jll: LocalMemoryBuffer, ObjectReference, RayObject, get_data_metadata
+
+@testset "RayObject" begin
+    @testset "get_data_metadata" begin
+        data = UInt16[1:3;]
+        metadata = b"22"
+        data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+        metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+        nested_refs = StdVector{ObjectReference}()
+
+        ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
+        result = get_data_metadata(ray_obj)
+
+        @test result isa Tuple{Vector{UInt8}, Vector{UInt8}}
+        @test result[1] == reinterpret(UInt8, data)
+        @test result[2] == metadata
+    end
+end

--- a/test/ray_julia_jll/ray_object.jl
+++ b/test/ray_julia_jll/ray_object.jl
@@ -1,21 +1,48 @@
-using .ray_julia_jll: LocalMemoryBuffer, ObjectReference, RayObject, get_data, get_metadata
+using .ray_julia_jll: Buffer, LocalMemoryBuffer, NullPtr, ObjectReference, RayObject,
+                      get_data, get_metadata
 
 @testset "RayObject" begin
     @testset "get_data / get_metadata" begin
-        data = UInt16[1:3;]
-        metadata = b"22"
+        @testset "non-null data/metadata" begin
+            data = UInt16[1:3;]
+            metadata = b"22"
 
-        data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
-        nested_refs = StdVector{ObjectReference}()
-        ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
+            data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+            metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+            nested_refs = StdVector{ObjectReference}()
+            ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
 
-        result = get_data(ray_obj)
-        @test result isa Vector{UInt8}
-        @test result == reinterpret(UInt8, data)
+            result = get_data(ray_obj)
+            @test result isa Vector{UInt8}
+            @test result == reinterpret(UInt8, data)
 
-        result = get_metadata(ray_obj)
-        @test result isa Vector{UInt8}
-        @test result == metadata
+            result = get_metadata(ray_obj)
+            @test result isa Vector{UInt8}
+            @test result == metadata
+        end
+
+        @testset "null data" begin
+            metadata = b"22"
+
+            data_buf = NullPtr(Buffer)
+            metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
+            nested_refs = StdVector{ObjectReference}()
+            ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
+
+            @test get_data(ray_obj) === nothing
+            @test get_metadata(ray_obj) == metadata
+        end
+
+        @testset "null metadata" begin
+            data = UInt16[1:3;]
+
+            data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+            metadata_buf = NullPtr(Buffer)
+            nested_refs = StdVector{ObjectReference}()
+            ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
+
+            @test get_data(ray_obj) == reinterpret(UInt8, data)
+            @test get_metadata(ray_obj) === nothing
+        end
     end
 end

--- a/test/ray_julia_jll/ray_object.jl
+++ b/test/ray_julia_jll/ray_object.jl
@@ -1,18 +1,21 @@
-using .ray_julia_jll: LocalMemoryBuffer, ObjectReference, RayObject, get_data_metadata
+using .ray_julia_jll: LocalMemoryBuffer, ObjectReference, RayObject, get_data, get_metadata
 
 @testset "RayObject" begin
-    @testset "get_data_metadata" begin
+    @testset "get_data / get_metadata" begin
         data = UInt16[1:3;]
         metadata = b"22"
+
         data_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
         metadata_buf = LocalMemoryBuffer(Ptr{Nothing}(pointer(metadata)), sizeof(metadata), true)
         nested_refs = StdVector{ObjectReference}()
-
         ray_obj = RayObject(data_buf, metadata_buf, nested_refs, false)
-        result = get_data_metadata(ray_obj)
 
-        @test result isa Tuple{Vector{UInt8}, Vector{UInt8}}
-        @test result[1] == reinterpret(UInt8, data)
-        @test result[2] == metadata
+        result = get_data(ray_obj)
+        @test result isa Vector{UInt8}
+        @test result == reinterpret(UInt8, data)
+
+        result = get_metadata(ray_obj)
+        @test result isa Vector{UInt8}
+        @test result == metadata
     end
 end

--- a/test/ray_julia_jll/runtests.jl
+++ b/test/ray_julia_jll/runtests.jl
@@ -15,6 +15,7 @@ end
     include("function_descriptor.jl")
     include("address.jl")
     include("objectid.jl")
+    include("ray_object.jl")
 
     setup_ray_head_node_basic() do
         # GCS client only needs head node

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -108,7 +108,7 @@ end
         metadata = b"hello\x00world"
 
         ray_obj = Ray.serialize_to_ray_object(data, metadata)
-        @test take!(ray_jll.GetMetadata(ray_obj[])[]) == metadata
+        @test ray_jll.get_metadata(ray_obj) == metadata
 
         @test_throws "Encountered unhandled metadata: hello\x00world" begin
             Ray.deserialize_from_ray_object(ray_obj)

--- a/test/ray_serializer.jl
+++ b/test/ray_serializer.jl
@@ -110,8 +110,11 @@ end
         ray_obj = Ray.serialize_to_ray_object(data, metadata)
         @test ray_jll.get_metadata(ray_obj) == metadata
 
-        @test_throws "Encountered unhandled metadata: hello\x00world" begin
-            Ray.deserialize_from_ray_object(ray_obj)
-        end
+        msg = "Encountered unhandled metadata: hello\x00world"
+        @test_throws msg Ray.deserialize_from_ray_object(ray_obj)
+
+        obj_ref = ObjectRef(ray_jll.FromRandom(ray_jll.ObjectID))
+        msg = "Encountered unhandled metadata from `$(repr(obj_ref))`: hello\x00world"
+        @test_throws msg Ray.deserialize_from_ray_object(ray_obj, obj_ref)
     end
 end


### PR DESCRIPTION
Split out from #184. Includes the following changes:

- Wraps `HasData` and `HasMetadata`
- Adds the function `get_data` and `get_metadata` as easy ways of fetching this data as `Vector{UInt8}`
- Support metadata in `serialize_to_ray_object`
- Throw an exception when encountering unhandled metadata. Avoids getting misleading error messages like in #143 but doesn't provide a nice user interface for what the metadata means.

The follow up to this PR will be parsing the metadata and either deserializing the data or returning an specific exception based upon the error type in the metadata (e.g. https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/serialization.py#L263-L364)