### PR TITLE
Improve robustness of `ObjectRef` ownership info serialization

### DIFF
--- a/src/Ray.jl
+++ b/src/Ray.jl
@@ -24,7 +24,7 @@ export start_worker, submit_task, @ray_import, ObjectRef
 export RayError, RaySystemError, RayTaskError
 
 include(joinpath("ray_julia_jll", "ray_julia_jll.jl"))
-using .ray_julia_jll: ray_julia_jll, ray_julia_jll as ray_jll
+using .ray_julia_jll: ray_julia_jll, ray_julia_jll as ray_jll, safe_convert
 
 include("exceptions.jl")
 include("function_manager.jl")

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -147,11 +147,12 @@ function Serialization.serialize(s::AbstractSerializer, obj_ref::ObjectRef)
     ray_jll.GetOwnershipInfo(worker, obj_ref.oid, CxxPtr(owner_address),
                              CxxPtr(serialized_object_status))
 
+    @debug "serialize ObjectRef:\noid: $hex_str\nowner address $owner_address"
+
     # Using `collect` to ensure that the entire string is captured and not just up to the
     # first null character. Will be fixed in:
     # https://github.com/JuliaInterop/CxxWrap.jl/pull/378
     owner_address_json = String(collect(ray_jll.MessageToJsonString(owner_address)))
-    @debug "serialize ObjectRef:\noid: $hex_str\nowner address $owner_address"
     serialized_object_status = String(collect(serialized_object_status))
 
     serialize_type(s, typeof(obj_ref))

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -118,11 +118,13 @@ function _register_ownership(obj_ref::ObjectRef, outer_obj_ref::Union{ObjectRef,
 
     worker = ray_jll.GetCoreWorker()
     if !isnothing(obj_ref.owner_address) && !has_owner(obj_ref)
+        serialized_object_status = safe_convert(StdString, obj_ref.serialized_object_status)
+
         # https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L3329
         # https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/core_worker.h#L543
         ray_jll.RegisterOwnershipInfoAndResolveFuture(worker, obj_ref.oid, outer_object_id,
                                                       owner_address,
-                                                      obj_ref.serialized_object_status)
+                                                      serialized_object_status)
     else
         if isnothing(obj_ref.owner_address)
             @debug "attempted to register ownership but owner address is nothing: $(obj_ref)"

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -169,8 +169,3 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{ObjectRef})
 
     return ObjectRef(hex_str, serialized_owner_address, serialized_object_status)
 end
-
-# Using `collect` and `ncodeunits` to ensure that the entire string is captured and not just
-# up to the first null character: https://github.com/JuliaInterop/CxxWrap.jl/pull/378
-safe_convert(::Type{String}, str::StdString) = String(Vector{UInt8}(collect(str)))
-safe_convert(::Type{StdString}, str::String) = StdString(str, ncodeunits(str))

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -5,9 +5,6 @@ mutable struct ObjectRef
 
     function ObjectRef(oid_hex, owner_address_json, serialized_object_status;
                        add_local_ref=true)
-        if owner_address_json !== nothing && isempty(owner_address_json)
-            owner_address_json = nothing
-        end
         objref = new(oid_hex, owner_address_json, serialized_object_status)
         if add_local_ref
             worker = ray_jll.GetCoreWorker()

--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -167,14 +167,13 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{ObjectRef})
     owner_address_json = deserialize(s)
     serialized_object_status = deserialize(s)
 
-    # this if/else block only exists for debug logging
-    if owner_address_json === nothing || isempty(owner_address_json)
-        owner_address_json = nothing
-        @debug "deserialize ObjectRef:\noid: $hex_str\nowner address: $owner_address_json"
-    else
-        std_str = StdString(owner_address_json, ncodeunits(owner_address_json))
-        owner_address = ray_jll.JsonStringToMessage(ray_jll.Address, std_str)
-        @debug "deserialize ObjectRef:\noid: $hex_str\nowner address: $owner_address"
+    @debug begin
+        owner_address = nothing
+        if !isempty(owner_address_json)
+            std_str = StdString(owner_address_json, ncodeunits(owner_address_json))
+            owner_address = ray_jll.JsonStringToMessage(ray_jll.Address, std_str)
+        end
+        "deserialize ObjectRef:\noid: $hex_str\nowner address: $owner_address"
     end
 
     return ObjectRef(hex_str, owner_address_json, serialized_object_status)

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -204,9 +204,10 @@ Base.show(io::IO, x::ObjectID) = write(io, "ObjectID(\"", Hex(x), "\")")
 # Base.:(==)(a::ObjectID, b::ObjectID) = Hex(a) == Hex(b)
 #
 # is shadowed by more specific fallbacks defined by CxxWrap.
-const ObjectIDTypes = (ObjectIDAllocated, ObjectIDDereferenced)
-for Ta in ObjectIDTypes, Tb in ObjectIDTypes
-    @eval Base.:(==)(a::$Ta, b::$Tb) = Hex(a) == Hex(b)
+let types = (ObjectIDAllocated, ObjectIDDereferenced)
+    for A in types, B in types
+        @eval Base.:(==)(a::$A, b::$B) = Hex(a) == Hex(b)
+    end
 end
 
 Base.hash(x::ObjectID, h::UInt) = hash(ObjectID, hash(Hex(x), h))

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -168,6 +168,24 @@ let types = (AddressAllocated, AddressDereferenced)
     end
 end
 
+function Serialization.serialize(s::AbstractSerializer, addr::Address)
+    serialized_addr = safe_convert(String, SerializeAsString(addr))
+
+    serialize_type(s, Address)
+    serialize(s, serialized_addr)
+
+    return nothing
+end
+
+function Serialization.deserialize(s::AbstractSerializer, ::Type{Address})
+    serialized_addr = deserialize(s)
+
+    addr = Address()
+    ParseFromString(addr, safe_convert(StdString, serialized_addr))
+
+    return addr
+end
+
 #####
 ##### Buffer
 #####

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -162,6 +162,12 @@ end
 # handle it on the C++ side rather than wrapping everything.
 Base.show(io::IO, addr::Address) = print(io, _string(addr))
 
+let types = (AddressAllocated, AddressDereferenced)
+    for A in types, B in types
+        @eval Base.:(==)(a::$A, b::$B) = MessageToJsonString(a) == MessageToJsonString(b)
+    end
+end
+
 #####
 ##### Buffer
 #####

--- a/src/ray_julia_jll/ray_julia_jll.jl
+++ b/src/ray_julia_jll/ray_julia_jll.jl
@@ -12,6 +12,7 @@ function __init__()
     @initcxx
 end  # __init__()
 
+include("upstream_fixes.jl")
 include("expr.jl")
 include("common.jl")
 

--- a/src/ray_julia_jll/ray_julia_jll.jl
+++ b/src/ray_julia_jll/ray_julia_jll.jl
@@ -3,7 +3,8 @@ module ray_julia_jll
 using Artifacts: @artifact_str
 using CxxWrap
 using CxxWrap.StdLib: StdVector, SharedPtr
-using Serialization
+using Serialization: Serialization, AbstractSerializer, deserialize, serialize,
+                     serialize_type
 using libcxxwrap_julia_jll
 
 @wrapmodule(joinpath(artifact"ray_julia", "julia_core_worker_lib.so"))

--- a/src/ray_julia_jll/upstream_fixes.jl
+++ b/src/ray_julia_jll/upstream_fixes.jl
@@ -1,0 +1,4 @@
+# Using `collect` and `ncodeunits` to ensure that the entire string is captured and not just
+# up to the first null character: https://github.com/JuliaInterop/CxxWrap.jl/pull/378
+safe_convert(::Type{String}, str::StdString) = String(Vector{UInt8}(collect(str)))
+safe_convert(::Type{StdString}, str::String) = StdString(str, ncodeunits(str))

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -13,13 +13,15 @@ end
         obj_ref = ObjectRef(hex_str)
         @test Ray.hex_identifier(obj_ref) == hex_str
         @test obj_ref.oid == ray_jll.FromHex(ray_jll.ObjectID, hex_str)
-        @test obj_ref.owner_address === nothing
+        @test obj_ref.owner_address == ray_jll.Address()
         @test obj_ref == ObjectRef(hex_str)
         @test hash(obj_ref) == hash(ObjectRef(hex_str))
+    end
 
-        # test "no owner address" constructors
-        @test ObjectRef(hex_str, nothing, "") == obj_ref
-        @test ObjectRef(hex_str, "", "") == obj_ref
+    @testset "no owner address constructors" begin
+        hex_str = "f"^(2 * 28)
+        @test ObjectRef(hex_str, "", "").owner_address == ray_jll.Address()
+        @test ObjectRef(hex_str, "{}", "").owner_address == ray_jll.Address()
     end
 
     @testset "show" begin

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -18,10 +18,9 @@ end
         @test hash(obj_ref) == hash(ObjectRef(hex_str))
     end
 
-    @testset "no owner address constructors" begin
+    @testset "no owner address constructor" begin
         hex_str = "f"^(2 * 28)
-        @test ObjectRef(hex_str, "", "").owner_address == ray_jll.Address()
-        @test ObjectRef(hex_str, "{}", "").owner_address == ray_jll.Address()
+        @test ObjectRef(hex_str, ray_jll.Address(), "").owner_address == ray_jll.Address()
     end
 
     @testset "show" begin

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -17,7 +17,7 @@ end
         @test obj_ref == ObjectRef(hex_str)
         @test hash(obj_ref) == hash(ObjectRef(hex_str))
 
-        # test various "no owner address" constructors
+        # test "no owner address" constructors
         @test ObjectRef(hex_str, nothing, "") == obj_ref
         @test ObjectRef(hex_str, "", "") == obj_ref
     end

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -7,6 +7,23 @@ function serialize_deserialize(x)
     return deserialize(io)
 end
 
+@testset "safe_convert" begin
+    expected = "¿\0ÿ"
+    cpp_expected = "Â¿\0Ã¿"
+
+    std_str = Ray.safe_convert(StdString, expected)
+    @test length(std_str) == length(cpp_expected)
+    @test collect(std_str) == collect(cpp_expected)
+    @test ncodeunits(std_str) == ncodeunits(expected)
+    @test codeunits(std_str) == codeunits(expected)
+
+    str = Ray.safe_convert(String, std_str)
+    @test length(str) == length(expected)
+    @test collect(str) == collect(expected)
+    @test ncodeunits(str) == ncodeunits(expected)
+    @test codeunits(str) == codeunits(expected)
+end
+
 @testset "ObjectRef" begin
     @testset "basic" begin
         hex_str = "f"^(2 * 28)

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -7,23 +7,6 @@ function serialize_deserialize(x)
     return deserialize(io)
 end
 
-@testset "safe_convert" begin
-    expected = "¿\0ÿ"
-    cpp_expected = "Â¿\0Ã¿"
-
-    std_str = Ray.safe_convert(StdString, expected)
-    @test length(std_str) == length(cpp_expected)
-    @test collect(std_str) == collect(cpp_expected)
-    @test ncodeunits(std_str) == ncodeunits(expected)
-    @test codeunits(std_str) == codeunits(expected)
-
-    str = Ray.safe_convert(String, std_str)
-    @test length(str) == length(expected)
-    @test collect(str) == collect(expected)
-    @test ncodeunits(str) == ncodeunits(expected)
-    @test codeunits(str) == codeunits(expected)
-end
-
 @testset "ObjectRef" begin
     @testset "basic" begin
         hex_str = "f"^(2 * 28)

--- a/test/object_store.jl
+++ b/test/object_store.jl
@@ -61,6 +61,24 @@
         result = Ray.deserialize_from_ray_object(Ray.serialize_to_ray_object(obj))
         @test result.owner_address == Ray.get_owner_address(obj)
     end
+
+    @testset "deepcopy object reference owner address" begin
+        obj1 = Ray.put(42)
+        addr = Ray.get_owner_address(obj1)
+        obj2 = ObjectRef(Ray.hex_identifier(obj1), addr, "")
+        obj3 = deepcopy(obj2)
+
+        @test obj1.owner_address != addr  # Usually only populated upon deserialization
+        @test obj2.owner_address == addr
+        @test obj3.owner_address == addr
+
+        finalize(obj2)
+        yield()
+
+        # Avoid comparing against `addr` here as the finalizer could modify it in place
+        # allowing this test to pass.
+        @test obj3.owner_address == Ray.get_owner_address(obj1)
+    end
 end
 
 @testset "serialize_to_ray_object" begin

--- a/test/object_store.jl
+++ b/test/object_store.jl
@@ -58,10 +58,8 @@
     @testset "Object owner" begin
         obj = Ray.put(1)
         # ownership only embedded in ObjectRef on serialization
-        obj_rt = Ray.deserialize_from_ray_object(Ray.serialize_to_ray_object(obj))
-        addr_json = ray_jll.MessageToJsonString(Ray.get_owner_address(obj))
-        addr_rt_json = ray_jll.MessageToJsonString(obj_rt.owner_address)
-        @test addr_json == addr_rt_json == obj_rt.owner_address_json
+        result = Ray.deserialize_from_ray_object(Ray.serialize_to_ray_object(obj))
+        @test result.owner_address == Ray.get_owner_address(obj)
     end
 end
 

--- a/test/ray_julia_jll/address.jl
+++ b/test/ray_julia_jll/address.jl
@@ -22,4 +22,13 @@ using .ray_julia_jll: Address
         result = ray_julia_jll.SerializeAsString(address)
         @test result == serialized_str
     end
+
+    @testset "julia serialization round-trip" begin
+        address = Address()
+        io = IOBuffer()
+        serialize(io, address)
+        seekstart(io)
+        result = deserialize(io)
+        @test result == address
+    end
 end

--- a/test/ray_julia_jll/address.jl
+++ b/test/ray_julia_jll/address.jl
@@ -1,6 +1,12 @@
 using .ray_julia_jll: Address
 
 @testset "Address" begin
+    @testset "equality" begin
+        addr = Address()
+        @test addr == Address()
+        @test addr == CxxPtr(Address())[]
+    end
+
     @testset "json round-trip" begin
         json = Dict(:rayletId => base64encode("raylet"), :ipAddress => "127.0.0.1",
                     :port => 10000, :workerId => base64encode("worker"))

--- a/test/ray_julia_jll/address.jl
+++ b/test/ray_julia_jll/address.jl
@@ -24,11 +24,22 @@ using .ray_julia_jll: Address
     end
 
     @testset "julia serialization round-trip" begin
-        address = Address()
-        io = IOBuffer()
-        serialize(io, address)
-        seekstart(io)
-        result = deserialize(io)
-        @test result == address
+        addr_alloc = Address()
+        @test addr_alloc isa ray_julia_jll.AddressAllocated
+        serialized_addr_alloc = sprint(serialize, addr_alloc)
+        result = deserialize(IOBuffer(serialized_addr_alloc))
+        @test result isa ray_julia_jll.AddressAllocated
+        @test result == addr_alloc
+
+
+        addr_ptr = CxxPtr(addr_alloc)
+        addr_deref = addr_ptr[]
+        @test addr_deref isa ray_julia_jll.AddressDereferenced
+        serialized_addr_deref = sprint(serialize, addr_deref)
+        result = deserialize(IOBuffer(serialized_addr_deref))
+        @test result isa ray_julia_jll.AddressAllocated
+        @test result == addr_deref
+
+        @test serialized_addr_deref == serialized_addr_alloc
     end
 end

--- a/test/ray_julia_jll/address.jl
+++ b/test/ray_julia_jll/address.jl
@@ -31,7 +31,6 @@ using .ray_julia_jll: Address
         @test result isa ray_julia_jll.AddressAllocated
         @test result == addr_alloc
 
-
         addr_ptr = CxxPtr(addr_alloc)
         addr_deref = addr_ptr[]
         @test addr_deref isa ray_julia_jll.AddressDereferenced

--- a/test/ray_julia_jll/runtests.jl
+++ b/test/ray_julia_jll/runtests.jl
@@ -12,6 +12,7 @@ f(x) = x + 1
 end
 
 @testset "ray_julia_jll.jl" begin
+    include("upstream_fixes.jl")
     include("expr.jl")
     include("buffer.jl")
     include("function_descriptor.jl")

--- a/test/ray_julia_jll/upstream_fixes.jl
+++ b/test/ray_julia_jll/upstream_fixes.jl
@@ -1,0 +1,16 @@
+@testset "safe_convert" begin
+    expected = "¿\0ÿ"
+    cpp_expected = "Â¿\0Ã¿"
+
+    std_str = Ray.safe_convert(StdString, expected)
+    @test length(std_str) == length(cpp_expected)
+    @test collect(std_str) == collect(cpp_expected)
+    @test ncodeunits(std_str) == ncodeunits(expected)
+    @test codeunits(std_str) == codeunits(expected)
+
+    str = Ray.safe_convert(String, std_str)
+    @test length(str) == length(expected)
+    @test collect(str) == collect(expected)
+    @test ncodeunits(str) == ncodeunits(expected)
+    @test codeunits(str) == codeunits(expected)
+end

--- a/test/task.jl
+++ b/test/task.jl
@@ -98,10 +98,10 @@ end
         @test Ray.has_owner(remote_ref)
 
         # Convert address to string to compare
-        return_ref_addr = ray_jll.MessageToJsonString(Ray.get_owner_address(return_ref))
-        remote_ref_addr = ray_jll.MessageToJsonString(Ray.get_owner_address(remote_ref))
+        return_ref_addr = Ray.get_owner_address(return_ref)
+        remote_ref_addr = Ray.get_owner_address(remote_ref)
         @test return_ref_addr != remote_ref_addr
-        @test remote_ref_addr == remote_ref.owner_address_json
+        @test remote_ref_addr == remote_ref.owner_address
 
         @test Ray.get(remote_ref) == 2
     end


### PR DESCRIPTION
While investigating #177 it was becoming evident that the flaw had something do with our worker addresses once again. As I so far have been unable to reproduce this problem locally I decided to look into audit our object reference ownership code to see if anything popped out. In doing so I recalled that in #140 we utilized JSON serialization for the owner address as we were having problems with CxxWrap `StdString` which would interpret the null-character as the end of the string instead of looking at the length of the string. The JSON approach doesn't actually fix anything except that it works around the issue. I decided to try to switch back to using `SerializeAsString` and apply our new CxxWrap knowledge to see if we could really fix the issue. In doing so I discovered that CxxWrap doesn't handle non-ASCII characters well:

```julia
julia> str = "¿\0ÿ"
"¿\0ÿ"

julia> collect(StdString(str, ncodeunits(str)))
5-element Vector{Char}:
 'Â': Unicode U+00C2 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)
 '\0': ASCII/Unicode U+0000 (category Cc: Other, control)
 'Ã': Unicode U+00C3 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)

julia> std_str = StdString(str, ncodeunits(str))
"¿"

julia> collect(String(std_str))
1-element Vector{Char}:
 '¿': Unicode U+00BF (category Po: Punctuation, other)

julia> collect(String(collect(std_str)))
5-element Vector{Char}:
 'Â': Unicode U+00C2 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)
 '\0': ASCII/Unicode U+0000 (category Cc: Other, control)
 'Ã': Unicode U+00C3 (category Lu: Letter, uppercase)
 '¿': Unicode U+00BF (category Po: Punctuation, other)

julia> collect(String(Vector{UInt8}(collect(std_str))))
3-element Vector{Char}:
 '¿': Unicode U+00BF (category Po: Punctuation, other)
 '\0': ASCII/Unicode U+0000 (category Cc: Other, control)
 'ÿ': Unicode U+00FF (category Ll: Letter, lowercase)
```

The flaw in CxxWrap is that the [`iterate`/`isvalid` implementation](https://github.com/JuliaInterop/CxxWrap.jl/blob/ecd527979b23730a6b30459adeed11afe9e24758/src/StdLib.jl#L39-L46) doesn't skip invalid code points (thanks @iamed2). I'll file an issue for that later today.

This PR implements a `safe_convert` function to ensure that C++ string data can be round-tripped as a Julia `String` and back. Doing this allows us to use `SerializeAsString` successfully. In iterating on this design I found that implementing serialization support for `Address` allowed us to clean up the interface for this resulting some cleaner code.

Fixes #177. 