### PR TITLE
Store ownership info in `RaySerializer`

### DIFF
--- a/src/object_ref.jl
+++ b/src/object_ref.jl
@@ -104,19 +104,21 @@ end
 function _register_ownership(obj_ref::ObjectRef, outer_obj_ref::Union{ObjectRef,Nothing},
                              owner_address::ray_jll.Address,
                              serialized_object_status::String)
-    @debug """Registering ownership for $(obj_ref)
-              owner address: $(owner_address)
-              status: $(bytes2hex(codeunits(serialized_object_status)))
-              contained in $(outer_obj_ref)"""
-
-    outer_object_id = if outer_obj_ref !== nothing
-        outer_obj_ref.oid
-    else
-        ray_jll.FromNil(ray_jll.ObjectID)
-    end
-
-    worker = ray_jll.GetCoreWorker()
     if !has_owner(obj_ref)
+        @debug """
+               Registering ownership for $(obj_ref)
+               owner address: $(owner_address)
+               status: $(bytes2hex(codeunits(serialized_object_status)))
+               contained in: $(outer_obj_ref)"""
+
+        worker = ray_jll.GetCoreWorker()
+
+        outer_object_id = if outer_obj_ref !== nothing
+            outer_obj_ref.oid
+        else
+            ray_jll.FromNil(ray_jll.ObjectID)
+        end
+
         serialized_object_status = safe_convert(StdString, serialized_object_status)
 
         # https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_raylet.pyx#L3329
@@ -125,7 +127,7 @@ function _register_ownership(obj_ref::ObjectRef, outer_obj_ref::Union{ObjectRef,
                                                       owner_address,
                                                       serialized_object_status)
     else
-        @debug "attempted to register ownership but object already has known owner: $(obj_ref)"
+        @debug "Skipping registering ownership for $(obj_ref) as object has known owner"
     end
 
     return nothing

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -139,9 +139,9 @@ function deserialize_from_ray_object(ray_obj::SharedPtr{ray_jll.RayObject},
     end
 
     for inner_object_ref in s.object_refs
-        metadata = s.object_owner[inner_object_ref]
-        _register_ownership(inner_object_ref, outer_object_ref, metadata.owner_address,
-                            metadata.serialized_object_status)
+        (; owner_address, serialized_object_status) = s.object_owner[inner_object_ref]
+        _register_ownership(inner_object_ref, outer_object_ref, owner_address,
+                            serialized_object_status)
     end
 
     # TODO: add an option to not rethrow

--- a/test/object_ref.jl
+++ b/test/object_ref.jl
@@ -13,14 +13,8 @@ end
         obj_ref = ObjectRef(hex_str)
         @test Ray.hex_identifier(obj_ref) == hex_str
         @test obj_ref.oid == ray_jll.FromHex(ray_jll.ObjectID, hex_str)
-        @test obj_ref.owner_address == ray_jll.Address()
         @test obj_ref == ObjectRef(hex_str)
         @test hash(obj_ref) == hash(ObjectRef(hex_str))
-    end
-
-    @testset "no owner address constructor" begin
-        hex_str = "f"^(2 * 28)
-        @test ObjectRef(hex_str, ray_jll.Address(), "").owner_address == ray_jll.Address()
     end
 
     @testset "show" begin

--- a/test/object_store.jl
+++ b/test/object_store.jl
@@ -59,24 +59,6 @@
         obj_ref = Ray.put(1)
         @test Ray.has_owner(obj_ref)
     end
-
-    @testset "deepcopy object reference owner address" begin
-        obj1 = Ray.put(42)
-        addr = Ray.get_owner_address(obj1)
-        obj2 = ObjectRef(Ray.hex_identifier(obj1), addr, "")
-        obj3 = deepcopy(obj2)
-
-        @test obj1.owner_address != addr  # Usually only populated upon deserialization
-        @test obj2.owner_address == addr
-        @test obj3.owner_address == addr
-
-        finalize(obj2)
-        yield()
-
-        # Avoid comparing against `addr` here as the finalizer could modify it in place
-        # allowing this test to pass.
-        @test obj3.owner_address == Ray.get_owner_address(obj1)
-    end
 end
 
 @testset "serialize_to_ray_object" begin

--- a/test/object_store.jl
+++ b/test/object_store.jl
@@ -56,10 +56,8 @@
     end
 
     @testset "Object owner" begin
-        obj = Ray.put(1)
-        # ownership only embedded in ObjectRef on serialization
-        result = Ray.deserialize_from_ray_object(Ray.serialize_to_ray_object(obj))
-        @test result.owner_address == Ray.get_owner_address(obj)
+        obj_ref = Ray.put(1)
+        @test Ray.has_owner(obj_ref)
     end
 
     @testset "deepcopy object reference owner address" begin

--- a/test/task.jl
+++ b/test/task.jl
@@ -97,11 +97,9 @@ end
         @test Ray.has_owner(return_ref)
         @test Ray.has_owner(remote_ref)
 
-        # Convert address to string to compare
         return_ref_addr = Ray.get_owner_address(return_ref)
         remote_ref_addr = Ray.get_owner_address(remote_ref)
         @test return_ref_addr != remote_ref_addr
-        @test remote_ref_addr == remote_ref.owner_address
 
         @test Ray.get(remote_ref) == 2
     end


### PR DESCRIPTION
Follow up to #203. Storing the owner address and the serialized object status in `ObjectRef` was rather strange as this information was only needed to finish the registration process after deserialization. This PR changes things to no longer be stored in `ObjectRef` but as part of the `RaySerializer` in a lookup table of object ref to ownership data.

Mainly this is just a refactoring of the existing code which should make it clearer that the extra `ObjectRef` fields are not needed all the time.