### PR TITLE
Parse ray runtime parameters from GlobalStateAccessor

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -368,6 +368,7 @@ namespace jlcxx
     template<> struct SuperType<rpc::Address> { typedef google::protobuf::Message type; };
     template<> struct SuperType<rpc::JobConfig> { typedef google::protobuf::Message type; };
     template<> struct SuperType<rpc::ObjectReference> { typedef google::protobuf::Message type; };
+    template<> struct SuperType<rpc::GcsNodeInfo> { typedef google::protobuf::Message type; };
     template<> struct SuperType<TaskArgByReference> { typedef TaskArg type; };
     template<> struct SuperType<TaskArgByValue> { typedef TaskArg type; };
 
@@ -678,6 +679,14 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     mod.add_type<rpc::ObjectReference>("ObjectReference", jlcxx::julia_base_type<google::protobuf::Message>());
     jlcxx::stl::apply_stl<rpc::ObjectReference>(mod);
 
+    // message GcsNodeInfo
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/protobuf/gcs.proto#L286
+    mod.add_type<rpc::GcsNodeInfo>("GcsNodeInfo", jlcxx::julia_base_type<google::protobuf::Message>())
+        .constructor<>()
+        .method("raylet_socket_name", &rpc::GcsNodeInfo::raylet_socket_name)
+        .method("object_store_socket_name", &rpc::GcsNodeInfo::object_store_socket_name)
+        .method("node_manager_port", &rpc::GcsNodeInfo::node_manager_port);
+
     // class RayObject
     // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/ray_object.h#L28
     mod.add_type<RayObject>("RayObject")
@@ -727,7 +736,8 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .constructor<const gcs::GcsClientOptions&>()
         .method("GetNextJobID", &ray::gcs::GlobalStateAccessor::GetNextJobID)
         .method("Connect", &ray::gcs::GlobalStateAccessor::Connect)
-        .method("Disconnect", &ray::gcs::GlobalStateAccessor::Disconnect);
+        .method("Disconnect", &ray::gcs::GlobalStateAccessor::Disconnect)
+        .method("GetNodeToConnectForDriver", &ray::gcs::GlobalStateAccessor::GetNodeToConnectForDriver);
 
     mod.method("report_error", &report_error);
 

--- a/build/wrapper.h
+++ b/build/wrapper.h
@@ -9,6 +9,7 @@
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/core_worker.h"
 #include "src/ray/protobuf/common.pb.h"
+#include "src/ray/protobuf/gcs.pb.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/gcs/gcs_client/global_state_accessor.h"
 #include "ray/common/asio/instrumented_io_context.h"

--- a/src/Ray.jl
+++ b/src/Ray.jl
@@ -26,6 +26,7 @@ export RayError, RaySystemError, RayTaskError
 include(joinpath("ray_julia_jll", "ray_julia_jll.jl"))
 using .ray_julia_jll: ray_julia_jll, ray_julia_jll as ray_jll
 
+include("constants.jl")
 include("exceptions.jl")
 include("function_manager.jl")
 include("runtime_env.jl")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -46,3 +46,5 @@ const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
 # In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
 # https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/services.py#L650-L658
 const NODE_IP_ADDRESS = "127.0.0.1"
+
+const DEFAULT_SESSION_DIR = "/tmp/ray/session_latest"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,0 +1,48 @@
+# NOTES:
+#
+# python function manager maintains a local table of "execution info" with a
+# "function_id" key and values that are named tuples of name/function/max_calls.
+#
+# python remote function sets a UUID4 at construction time:
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L128
+#
+# ...that's used to set the function_hash (???)...
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L263-L265
+#
+# later comment suggests that "ideally" they'd use the hash of the pickled
+# function:
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/includes/function_descriptor.pxi#L183-L186
+#
+# ...but that it's not stable for some reason.  but.....neither is a random
+# UUID?????
+#
+# the function table key is built like
+# <key type>:<jobid>:key
+
+# function manager holds:
+# local cache of functions (keyed by function id/hash from descriptor)
+# gcs client
+# ~~maybe job id?~~ this is managed by the core worker process
+
+# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/ray_constants.py#L122-L123
+const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000  # in bytes
+const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000  # in bytes
+
+# python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/_private/ray_constants.py#L380
+# so "jlfun" seems reasonable
+const FUNCTION_MANAGER_NAMESPACE = "jlfun"
+
+# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746
+const _check_msg = "Check that its definition is not implicitly capturing a large " *
+                   "array or other object in scope. Tip: use `Ray.put()` to put large " *
+                   "objects in the Ray object store."
+
+
+# env var to control whether logs are sent do stderr or to file.  if "1", sent
+# to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
+# https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198
+const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
+
+# In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
+# https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/services.py#L650-L658
+const NODE_IP_ADDRESS = "127.0.0.1"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -32,11 +32,6 @@ const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000  # in bytes
 # so "jlfun" seems reasonable
 const FUNCTION_MANAGER_NAMESPACE = "jlfun"
 
-# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746
-const _check_msg = "Check that its definition is not implicitly capturing a large " *
-                   "array or other object in scope. Tip: use `Ray.put()` to put large " *
-                   "objects in the Ray object store."
-
 # env var to control whether logs are sent do stderr or to file.  if "1", sent
 # to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
 # https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -48,3 +48,5 @@ const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
 const NODE_IP_ADDRESS = "127.0.0.1"
 
 const DEFAULT_SESSION_DIR = "/tmp/ray/session_latest"
+
+const GCS_ADDRESS_FILE = "/tmp/ray/ray_current_cluster"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -37,7 +37,6 @@ const _check_msg = "Check that its definition is not implicitly capturing a larg
                    "array or other object in scope. Tip: use `Ray.put()` to put large " *
                    "objects in the Ray object store."
 
-
 # env var to control whether logs are sent do stderr or to file.  if "1", sent
 # to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
 # https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198

--- a/src/function_manager.jl
+++ b/src/function_manager.jl
@@ -1,6 +1,5 @@
 _mib_string(num_bytes) = string(div(num_bytes, 1024 * 1024), " MiB")
 
-
 function check_oversized_function(serialized, function_descriptor)
     len = length(serialized)
     if len > FUNCTION_SIZE_ERROR_THRESHOLD

--- a/src/function_manager.jl
+++ b/src/function_manager.jl
@@ -1,5 +1,10 @@
 _mib_string(num_bytes) = string(div(num_bytes, 1024 * 1024), " MiB")
 
+# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746
+const _check_msg = "Check that its definition is not implicitly capturing a large " *
+                   "array or other object in scope. Tip: use `Ray.put()` to put large " *
+                   "objects in the Ray object store."
+
 function check_oversized_function(serialized, function_descriptor)
     len = length(serialized)
     if len > FUNCTION_SIZE_ERROR_THRESHOLD

--- a/src/function_manager.jl
+++ b/src/function_manager.jl
@@ -1,38 +1,5 @@
-# NOTES:
-#
-# python function manager maintains a local table of "execution info" with a
-# "function_id" key and values that are named tuples of name/function/max_calls.
-#
-# python remote function sets a UUID4 at construction time:
-# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L128
-#
-# ...that's used to set the function_hash (???)...
-# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L263-L265
-#
-# later comment suggests that "ideally" they'd use the hash of the pickled
-# function:
-# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/includes/function_descriptor.pxi#L183-L186
-#
-# ...but that it's not stable for some reason.  but.....neither is a random
-# UUID?????
-#
-# the function table key is built like
-# <key type>:<jobid>:key
-
-# function manager holds:
-# local cache of functions (keyed by function id/hash from descriptor)
-# gcs client
-# ~~maybe job id?~~ this is managed by the core worker process
-
-# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/ray_constants.py#L122-L123
-const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000  # in bytes
-const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000  # in bytes
-
 _mib_string(num_bytes) = string(div(num_bytes, 1024 * 1024), " MiB")
-# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746
-const _check_msg = "Check that its definition is not implicitly capturing a large " *
-                   "array or other object in scope. Tip: use `Ray.put()` to put large " *
-                   "objects in the Ray object store."
+
 
 function check_oversized_function(serialized, function_descriptor)
     len = length(serialized)
@@ -50,10 +17,6 @@ function check_oversized_function(serialized, function_descriptor)
     end
     return nothing
 end
-
-# python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/_private/ray_constants.py#L380
-# so "jlfun" seems reasonable
-const FUNCTION_MANAGER_NAMESPACE = "jlfun"
 
 Base.@kwdef struct FunctionManager
     gcs_client::ray_jll.JuliaGcsClient

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -96,6 +96,8 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
 
     raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS)
 
+    # TODO: downgrade to debug
+    # https://github.com/beacon-biosignals/Ray.jl/issues/53
     @info begin
         "Raylet socket: $raylet, Object store: $store, Node IP: $NODE_IP_ADDRESS, " *
         "Node port: $node_port, GCS Address: $gcs_address, JobID: $job_id"

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -61,7 +61,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-    gcs_address = read(GCS_ADDRESS_FILE, String) # host:port (e.g. 127.0.0.1:6379)
+    gcs_address = read(GCS_ADDRESS_FILE, String) # host:port (e.g. "127.0.0.1:6379")
 
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)
@@ -94,14 +94,8 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         "Node port: $node_port, GCS Address: $gcs_address, JobID: $job_id"
     end
 
-    ray_jll.initialize_driver(raylet,
-                              store,
-                              gcs_address,
-                              NODE_IP_ADDRESS,
-                              node_port,
-                              job_id,
-                              logs_dir,
-                              serialized_job_config)
+    ray_jll.initialize_driver(raylet, store, gcs_address, NODE_IP_ADDRESS, node_port,
+                              job_id, logs_dir, serialized_job_config)
 
     atexit(ray_jll.shutdown_driver)
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -39,7 +39,7 @@ function default_log_dir(session_dir)
 end
 
 function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
-              session_dir="/tmp/ray/session_latest",
+              session_dir=DEFAULT_SESSION_DIR,
               logs_dir=default_log_dir(session_dir))
     # XXX: this is at best EXREMELY IMPERFECT check.  we should do something
     # more like what hte python Worker class does, getting node ID at

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -179,12 +179,7 @@ function parse_ray_args_from_raylet_out(session_dir)
     end
 
     # --gcs-address=127.0.0.1:6379
-    gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5})", line)
-    gcs_address = if gcs_match !== nothing
-        String(gcs_match[1])
-    else
-        error("Unable to find GCS address")
-    end
+    gcs_address = read("/tmp/ray/ray_current_cluster", String)
 
     # --node-ip-address=127.0.0.1
     node_ip_match = match(r"node-ip-address=(([0-9]{1,3}\.){3}[0-9]{1,3})", line)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -91,7 +91,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     serialized_job_config = _serialize(job_config)
 
     # node-ip-address=127.0.0.1
-    node_ip_json = JSON3.read(joinpath(session_dir, "/node_ip_address.json"))
+    node_ip_json = JSON3.read(joinpath(session_dir, "node_ip_address.json"))
     node_ip = node_ip_json[:node_ip_address]
 
     node_info = CxxPtr{String}

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -123,10 +123,10 @@ Get the current task ID for this worker in hex format.
 get_task_id() = String(ray_jll.Hex(ray_jll.GetCurrentTaskId(ray_jll.GetCoreWorker())))
 
 function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
-    node_to_connect = CxxPtr(StdString())
+    node_to_connect = StdString()
     status = ray_jll.GetNodeToConnectForDriver(global_state_accessor, node_ip_address,
-                                               node_to_connect)
-    node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect[])
+                                               CxxPtr(node_to_connect))
+    node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect)
 
     raylet_socket_name = ray_jll.raylet_socket_name(node_info)[]
     store_socket_name = ray_jll.object_store_socket_name(node_info)[]

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -1,8 +1,5 @@
 const JOB_RUNTIME_ENV = Ref{RuntimeEnv}()
 
-# In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
-const NODE_IP_ADDRESS = "127.0.0.1"
-
 macro ray_import(ex)
     Ray = gensym(:Ray)
     result = quote
@@ -379,7 +376,7 @@ function start_worker(args=ARGS)
     return ray_jll.initialize_worker(parsed_args["raylet_socket"],
                                      parsed_args["store_socket"],
                                      parsed_args["address"],
-                                     parsed_args["NODE_IP_ADDRESS"],
+                                     parsed_args["node_ip_address"],
                                      parsed_args["node_manager_port"],
                                      parsed_args["startup_token"],
                                      parsed_args["runtime_env_hash"],

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -95,6 +95,11 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
 
     raylet, store, node_port = get_node_to_connect_for_driver()
 
+    @info begin
+        "Raylet socket: $raylet, Object store: $store, Node IP: $NODE_IP_ADDRESS_ADDRESS, " *
+        "Node port: $node_port, GCS Address: $gcs_address, JobID: $job_id"
+    end
+
     ray_jll.initialize_driver(raylet,
                               store,
                               gcs_address,

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -1,5 +1,8 @@
 const JOB_RUNTIME_ENV = Ref{RuntimeEnv}()
 
+# In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
+const NODE_IP_ADDRESS = "127.0.0.1"
+
 macro ray_import(ex)
     Ray = gensym(:Ray)
     result = quote

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -7,16 +7,7 @@ store name, node manager port, and the next job IDJob ID for the driver.
 """
 const GLOBAL_STATE_ACCESSOR = Ref{ray_jll.GlobalStateAccessor}()
 
-# env var to control whether logs are sent do stderr or to file.  if "1", sent
-# to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
-# https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198
-const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
-
 const JOB_RUNTIME_ENV = Ref{RuntimeEnv}()
-
-# In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
-# https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/services.py#L650-L658
-const NODE_IP_ADDRESS = "127.0.0.1"
 
 macro ray_import(ex)
     Ray = gensym(:Ray)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -128,8 +128,8 @@ function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
                                                CxxPtr(node_to_connect))
     node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect)
 
-    raylet_socket_name = ray_jll.raylet_socket_name(node_info)[])::StdString
-    store_socket_name = ray_jll.object_store_socket_name(node_info)[])::StdString
+    raylet_socket_name = ray_jll.raylet_socket_name(node_info)[]::StdString
+    store_socket_name = ray_jll.object_store_socket_name(node_info)[]::StdString
     node_manager_port = ray_jll.node_manager_port(node_info)::Int
 
     return (raylet_socket_name, store_socket_name, node_manager_port)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -70,7 +70,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-    #gcs-address=127.0.0.1:6379
+    # gcs-address=127.0.0.1:6379
     gcs_address = read("/tmp/ray/ray_current_cluster", String)
 
     opts = ray_jll.GcsClientOptions(gcs_address)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -130,7 +130,7 @@ function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
 
     raylet_socket_name = ray_jll.raylet_socket_name(node_info)[]::StdString
     store_socket_name = ray_jll.object_store_socket_name(node_info)[]::StdString
-    node_manager_port = ray_jll.node_manager_port(node_info)::Int
+    node_manager_port = ray_jll.node_manager_port(node_info)::Integer
 
     return (raylet_socket_name, store_socket_name, node_manager_port)
 end

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -128,9 +128,9 @@ function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
                                                CxxPtr(node_to_connect))
     node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect)
 
-    raylet_socket_name = ray_jll.raylet_socket_name(node_info)[]
-    store_socket_name = ray_jll.object_store_socket_name(node_info)[]
-    node_manager_port = ray_jll.node_manager_port(node_info)
+    raylet_socket_name = ray_jll.raylet_socket_name(node_info)[])::StdString
+    store_socket_name = ray_jll.object_store_socket_name(node_info)[])::StdString
+    node_manager_port = ray_jll.node_manager_port(node_info)::Int
 
     return (raylet_socket_name, store_socket_name, node_manager_port)
 end

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -67,16 +67,15 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-    # TODO: use something like the java config bootstrap address (?) to get this
-    # https://github.com/beacon-biosignals/Ray.jl/issues/52
-    # information instead of parsing logs?  I can't quite tell where it's coming
-    # from (set from a `ray.address` config option):
-    # https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java#L165-L171
+     #gcs-address=127.0.0.1:6379
+    gcs_address = read("/tmp/ray/ray_current_cluster", String)
 
-    # we use session_dir here instead of logs_dir since logs_dir can be set to
-    # "" to disable file logging without using env var
-    args = parse_ray_args_from_raylet_out(session_dir)
-    gcs_address = args[3]
+    # node-ip-address=127.0.0.1
+    node_ip_json = JSON3.read(joinpath(session_dir, "/node_ip_address.json"))
+    node_ip = node_ip_json[:node_ip_address]
+
+    node_info = CxxPtr{String}
+    status = ray_jll.GetNodeToConnectForDriver(GLOBAL_STATE_ACCESSOR[], node_ip, node_info)
 
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)
@@ -97,6 +96,8 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
 
     job_config = JobConfig(RuntimeEnvInfo(runtime_env), metadata)
     serialized_job_config = _serialize(job_config)
+
+    args = (raylet, store, gcs_address, node_ip, node_port)
 
     ray_jll.initialize_driver(args..., job_id, logs_dir, serialized_job_config)
     atexit(ray_jll.shutdown_driver)
@@ -135,72 +136,6 @@ function get_node_to_connect_for_driver(node_ip)
     node_manager_port = ray_jll.node_manager_port(node_info)
 
     return (raylet_socket_name, store_socket_name, node_manager_port)
-end
-
-function parse_ray_args_from_raylet_out(session_dir)
-    #=
-    "Starting agent process with command: ... \
-    --node-ip-address=127.0.0.1 --metrics-export-port=60404 --dashboard-agent-port=60493 \
-    --listen-port=52365 --node-manager-port=58888 \
-    --object-store-name=/tmp/ray/session_2023-08-14_14-54-36_055139_41385/sockets/plasma_store \
-    --raylet-name=/tmp/ray/session_2023-08-14_14-54-36_055139_41385/sockets/raylet \
-    --temp-dir=/tmp/ray --session-dir=/tmp/ray/session_2023-08-14_14-54-36_055139_41385 \
-    --runtime-env-dir=/tmp/ray/session_2023-08-14_14-54-36_055139_41385/runtime_resources \
-    --log-dir=/tmp/ray/session_2023-08-14_14-54-36_055139_41385/logs \
-    --logging-rotate-bytes=536870912 --logging-rotate-backup-count=5 \
-    --session-name=session_2023-08-14_14-54-36_055139_41385 \
-    --gcs-address=127.0.0.1:6379 --minimal --agent-id 470211272"
-    =#
-    line = open(joinpath(session_dir, "logs", "raylet.out")) do io
-        while !eof(io)
-            line = readline(io)
-            if contains(line, "Starting agent process")
-                return line
-            end
-        end
-    end
-
-    line !== nothing || error("Unable to locate agent process information")
-
-    # --raylet-name=/tmp/ray/session_2023-08-14_18-52-23_003681_54068/sockets/raylet
-    raylet_match = match(r"raylet-name=((\/[a-z,0-9,_,-]+)+)", line)
-    raylet = if raylet_match !== nothing
-        String(raylet_match[1])
-    else
-        error("Unable to find Raylet socket")
-    end
-
-    # --object-store-name=/tmp/ray/session_2023-08-14_18-52-23_003681_54068/sockets/plasma_store
-    store_match = match(r"object-store-name=((\/[a-z,0-9,_,-]+)+)", line)
-    store = if store_match !== nothing
-        String(store_match[1])
-    else
-        error("Unable to find Object Store socket")
-    end
-
-    # --gcs-address=127.0.0.1:6379
-    gcs_address = read("/tmp/ray/ray_current_cluster", String)
-
-    # --node-ip-address=127.0.0.1
-    node_ip_json = JSON3.read(joinpath(session_dir, "/node_ip_address.json"))
-    node_ip = node_ip_json[:node_ip_address]
-
-    # --node-manager-port=63639
-    port_match = match(r"node-manager-port=([0-9]{1,5})", line)
-    node_port = if port_match !== nothing
-        parse(Int, port_match[1])
-    else
-        error("Unable to find Node Manager port")
-    end
-
-    # TODO: downgrade to debug
-    # https://github.com/beacon-biosignals/Ray.jl/issues/53
-    @info begin
-        "Raylet socket: $raylet, Object store: $store, Node IP: $node_ip, " *
-        "Node port: $node_port, GCS Address: $gcs_address"
-    end
-
-    return (raylet, store, gcs_address, node_ip, node_port)
 end
 
 initialize_coreworker_driver(args...) = ray_jll.initialize_coreworker_driver(args...)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -1,3 +1,18 @@
+"""
+    const GLOBAL_STATE_ACCESSOR::Ref{ray_jll.GlobalStateAccessor}
+
+Global binding for GCS client interface to access global state information.
+Currently only used to get the next job ID.
+
+This is set during `init` and used there to get the Job ID for the driver.
+"""
+const GLOBAL_STATE_ACCESSOR = Ref{ray_jll.GlobalStateAccessor}()
+
+# env var to control whether logs are sent do stderr or to file.  if "1", sent
+# to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
+# https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198
+const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
+
 const JOB_RUNTIME_ENV = Ref{RuntimeEnv}()
 
 # In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
@@ -23,21 +38,6 @@ function _ray_import(runtime_env::RuntimeEnv)
     JOB_RUNTIME_ENV[] = runtime_env
     return nothing
 end
-
-"""
-    const GLOBAL_STATE_ACCESSOR::Ref{ray_jll.GlobalStateAccessor}
-
-Global binding for GCS client interface to access global state information.
-Currently only used to get the next job ID.
-
-This is set during `init` and used there to get the Job ID for the driver.
-"""
-const GLOBAL_STATE_ACCESSOR = Ref{ray_jll.GlobalStateAccessor}()
-
-# env var to control whether logs are sent do stderr or to file.  if "1", sent
-# to stderr; otherwise, will be sent to files in `/tmp/ray/session_latest/logs/`
-# https://github.com/beacon-biosignals/ray/blob/4ceb62daaad05124713ff9d94ffbdad35ee19f86/python/ray/_private/ray_constants.py#L198
-const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
 
 function default_log_dir(session_dir)
     redirect_logs = Base.get(ENV, LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE, "0") == "1"

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -93,8 +93,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     job_config = JobConfig(RuntimeEnvInfo(runtime_env), metadata)
     serialized_job_config = _serialize(job_config)
 
-    node_info = CxxPtr{String}
-    status = ray_jll.GetNodeToConnectForDriver(GLOBAL_STATE_ACCESSOR[], NODE_IP_ADDRESS, node_info)
+    raylet, store, node_port = get_node_to_connect_for_driver()
 
     ray_jll.initialize_driver(raylet,
                               store,

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -138,9 +138,9 @@ Get the current task ID for this worker in hex format.
 """
 get_task_id() = String(ray_jll.Hex(ray_jll.GetCurrentTaskId(ray_jll.GetCoreWorker())))
 
-function get_node_to_connect_for_driver(global_state_access, node_ip_address)
+function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
     node_to_connect = CxxPtr(StdString())
-    status = ray_jll.GetNodeToConnectForDriver(global_state_access[], node_ip_address,
+    status = ray_jll.GetNodeToConnectForDriver(global_state_accessor[], node_ip_address,
                                                node_to_connect)
     node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect[])
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -182,12 +182,8 @@ function parse_ray_args_from_raylet_out(session_dir)
     gcs_address = read("/tmp/ray/ray_current_cluster", String)
 
     # --node-ip-address=127.0.0.1
-    node_ip_match = match(r"node-ip-address=(([0-9]{1,3}\.){3}[0-9]{1,3})", line)
-    node_ip = if node_ip_match !== nothing
-        String(node_ip_match[1])
-    else
-        error("Unable to find Node IP address")
-    end
+    node_ip_json = JSON3.read(joinpath(session_dir, "/node_ip_address.json"))
+    node_ip = node_ip_json[:node_ip_address]
 
     # --node-manager-port=63639
     port_match = match(r"node-manager-port=([0-9]{1,5})", line)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -1,6 +1,7 @@
 const JOB_RUNTIME_ENV = Ref{RuntimeEnv}()
 
 # In ray-2.5.1 this is constant but in later versions it's read from NODE_IP_ADDRESS.json
+# https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/services.py#L650-L658
 const NODE_IP_ADDRESS = "127.0.0.1"
 
 macro ray_import(ex)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -94,7 +94,8 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     job_config = JobConfig(RuntimeEnvInfo(runtime_env), metadata)
     serialized_job_config = _serialize(job_config)
 
-    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS)
+    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR,
+                                                              NODE_IP_ADDRESS)
 
     # TODO: downgrade to debug
     # https://github.com/beacon-biosignals/Ray.jl/issues/53

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -96,7 +96,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     raylet, store, node_port = get_node_to_connect_for_driver()
 
     @info begin
-        "Raylet socket: $raylet, Object store: $store, Node IP: $NODE_IP_ADDRESS_ADDRESS, " *
+        "Raylet socket: $raylet, Object store: $store, Node IP: $NODE_IP_ADDRESS, " *
         "Node port: $node_port, GCS Address: $gcs_address, JobID: $job_id"
     end
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -61,7 +61,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-    gcs_address = read("/tmp/ray/ray_current_cluster", String) # host:port (e.g. 127.0.0.1:6379)
+    gcs_address = read(GCS_ADDRESS_FILE, String) # host:port (e.g. 127.0.0.1:6379)
 
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -70,8 +70,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-    # gcs-address=127.0.0.1:6379
-    gcs_address = read("/tmp/ray/ray_current_cluster", String)
+    gcs_address = read("/tmp/ray/ray_current_cluster", String) # host:port (e.g. 127.0.0.1:6379)
 
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -94,7 +94,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     job_config = JobConfig(RuntimeEnvInfo(runtime_env), metadata)
     serialized_job_config = _serialize(job_config)
 
-    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR,
+    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR[],
                                                               NODE_IP_ADDRESS)
 
     # TODO: downgrade to debug
@@ -140,7 +140,7 @@ get_task_id() = String(ray_jll.Hex(ray_jll.GetCurrentTaskId(ray_jll.GetCoreWorke
 
 function get_node_to_connect_for_driver(global_state_accessor, node_ip_address)
     node_to_connect = CxxPtr(StdString())
-    status = ray_jll.GetNodeToConnectForDriver(global_state_accessor[], node_ip_address,
+    status = ray_jll.GetNodeToConnectForDriver(global_state_accessor, node_ip_address,
                                                node_to_connect)
     node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect[])
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -2,9 +2,8 @@
     const GLOBAL_STATE_ACCESSOR::Ref{ray_jll.GlobalStateAccessor}
 
 Global binding for GCS client interface to access global state information.
-Currently only used to get the next job ID.
-
-This is set during `init` and used there to get the Job ID for the driver.
+This is set during [`Ray.init`](@ref) and used there to get the the raylet name, object
+store name, node manager port, and the next job IDJob ID for the driver.
 """
 const GLOBAL_STATE_ACCESSOR = Ref{ray_jll.GlobalStateAccessor}()
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -94,7 +94,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
     job_config = JobConfig(RuntimeEnvInfo(runtime_env), metadata)
     serialized_job_config = _serialize(job_config)
 
-    raylet, store, node_port = get_node_to_connect_for_driver()
+    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS)
 
     @info begin
         "Raylet socket: $raylet, Object store: $store, Node IP: $NODE_IP_ADDRESS, " *
@@ -135,9 +135,9 @@ Get the current task ID for this worker in hex format.
 """
 get_task_id() = String(ray_jll.Hex(ray_jll.GetCurrentTaskId(ray_jll.GetCoreWorker())))
 
-function get_node_to_connect_for_driver()
+function get_node_to_connect_for_driver(global_state_access, node_ip_address)
     node_to_connect = CxxPtr(StdString())
-    status = ray_jll.GetNodeToConnectForDriver(GLOBAL_STATE_ACCESSOR[], NODE_IP_ADDRESS,
+    status = ray_jll.GetNodeToConnectForDriver(global_state_access[], node_ip_address,
                                                node_to_connect)
     node_info = ray_jll.ParseFromString(ray_jll.GcsNodeInfo, node_to_connect[])
 
@@ -303,7 +303,7 @@ julia -e 'using Ray; start_worker()' -- \
   --ray_redis_password= \
   --ray_session_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400 \
   --ray_logs_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/logs \
-  --ray_node_ip_ADDRESS=127.0.0.1
+  --ray_node_ip_address=127.0.0.1
 =#
 function start_worker(args=ARGS)
     s = ArgParseSettings()

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -70,12 +70,13 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
         runtime_env = JOB_RUNTIME_ENV[]
     end
 
-     #gcs-address=127.0.0.1:6379
+    #gcs-address=127.0.0.1:6379
     gcs_address = read("/tmp/ray/ray_current_cluster", String)
 
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)
-    ray_jll.Connect(GLOBAL_STATE_ACCESSOR[]) || error("Failed to connect to Ray GCS at $(gcs_address)")
+    ray_jll.Connect(GLOBAL_STATE_ACCESSOR[]) ||
+        error("Failed to connect to Ray GCS at $(gcs_address)")
     atexit(() -> ray_jll.Disconnect(GLOBAL_STATE_ACCESSOR[]))
 
     job_id = ray_jll.GetNextJobID(GLOBAL_STATE_ACCESSOR[])

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -12,11 +12,11 @@
     raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR[],
                                                               NODE_IP_ADDRESS)
 
-    raylet_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/raylet"
-    @test !isnothing(match(raylet_regex, String(raylet)))
+    raylet_regex = r"^/tmp/ray/session_[0-9_-]+/sockets/raylet"
+    @test occursin(raylet_regex, String(raylet))
 
     store_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/plasma_store"
-    @test !isnothing(match(store_regex, String(store)))
+    @test occursin(store_regex, String(store))
 
     @test node_port isa Number
 

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -1,7 +1,8 @@
 @testset "GlobalStateAccessor" begin
-    using Ray: GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS, get_node_to_connect_for_driver
+    using Ray: GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS, get_node_to_connect_for_driver,
+               GCS_ADDRESS_FILE
 
-    gcs_address = read("/tmp/ray/ray_current_cluster", String)
+    gcs_address = read(GCS_ADDRESS_FILE, String)
     opts = ray_jll.GcsClientOptions(gcs_address)
     GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)
     ray_jll.Connect(GLOBAL_STATE_ACCESSOR[])

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -1,0 +1,28 @@
+@testset "GlobalStateAccessor" begin
+    using Ray: GLOBAL_STATE_ACCESSOR, NODE_IP_ADDRESS, get_node_to_connect_for_driver
+
+    gcs_address = read("/tmp/ray/ray_current_cluster", String)
+    opts = ray_jll.GcsClientOptions(gcs_address)
+    GLOBAL_STATE_ACCESSOR[] = ray_jll.GlobalStateAccessor(opts)
+    ray_jll.Connect(GLOBAL_STATE_ACCESSOR[])
+
+    # Note: passing in a fake node IP address won't throw an error, instead it reports a
+    # RAY_LOG(INFO) message about not finding a local Raylet with that address
+    # https://github.com/beacon-biosignals/ray/blob/448a83caf44108fc1bc44fa7c6c358cffcfcb0d7/src/ray/gcs/gcs_client/global_state_accessor.cc#L356-L359
+    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR,
+                                                              NODE_IP_ADDRESS)
+
+    @show raylet, store, node_port
+
+    @show typeof(raylet), typeof(store), typeof(node_port)
+
+    raylet_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/raylet"
+    @test !isnothing(match(raylet_regex, String(raylet)))
+
+    store_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/plasma_store"
+    @test !isnothing(match(store_regex, String(store)))
+
+    @test node_port isa Number
+
+    ray_jll.Disconnect(GLOBAL_STATE_ACCESSOR[])
+end

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -13,13 +13,12 @@
     raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR[],
                                                               NODE_IP_ADDRESS)
 
-    raylet_regex = r"^/tmp/ray/session_[0-9_-]+/sockets/raylet"
-    @test occursin(raylet_regex, String(raylet))
-
-    store_regex = r"^/tmp/ray/session_[0-9_-]+/sockets/plasma_store"
-    @test occursin(store_regex, String(store))
-
-    @test node_port isa Number
+    @test raylet isa StdString
+    @test occursin(r"^/tmp/ray/session_[0-9_-]+/sockets/raylet", raylet)
+    @test store isa StdString
+    @test occursin(r"^/tmp/ray/session_[0-9_-]+/sockets/plasma_store", store)
+    @test node_port isa Integer
+    @test 0 <= node_port <= 65535
 
     ray_jll.Disconnect(GLOBAL_STATE_ACCESSOR[])
 end

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -9,7 +9,7 @@
     # Note: passing in a fake node IP address won't throw an error, instead it reports a
     # RAY_LOG(INFO) message about not finding a local Raylet with that address
     # https://github.com/beacon-biosignals/ray/blob/448a83caf44108fc1bc44fa7c6c358cffcfcb0d7/src/ray/gcs/gcs_client/global_state_accessor.cc#L356-L359
-    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR,
+    raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR[],
                                                               NODE_IP_ADDRESS)
 
     raylet_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/raylet"

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -12,10 +12,6 @@
     raylet, store, node_port = get_node_to_connect_for_driver(GLOBAL_STATE_ACCESSOR,
                                                               NODE_IP_ADDRESS)
 
-    @show raylet, store, node_port
-
-    @show typeof(raylet), typeof(store), typeof(node_port)
-
     raylet_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/raylet"
     @test !isnothing(match(raylet_regex, String(raylet)))
 

--- a/test/global_state_accessor.jl
+++ b/test/global_state_accessor.jl
@@ -16,7 +16,7 @@
     raylet_regex = r"^/tmp/ray/session_[0-9_-]+/sockets/raylet"
     @test occursin(raylet_regex, String(raylet))
 
-    store_regex = r"^/tmp/ray/session_[0-9,_,-]+/sockets/plasma_store"
+    store_regex = r"^/tmp/ray/session_[0-9_-]+/sockets/plasma_store"
     @test occursin(store_regex, String(store))
 
     @test node_port isa Number

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include("utils.jl")
 
     setup_ray_head_node() do
         include("function_manager.jl")
+        include("global_state_accessor.jl")
         setup_core_worker() do
             include("object_ref.jl")
             include("ray_serializer.jl")


### PR DESCRIPTION
Break off of #202 

Closes #52 

- gcs address: `/tmp/ray/ray_current_cluster`
- node ip address: [const "127.0.0.1](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/services.py#L650-L658) (later it comes from its own file)
- raylet, store, port: GlobalStateAccessor

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205744051874128
  - https://app.asana.com/0/0/1205770557599276