### PR TITLE
pass `max_retries` during task submission

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -144,7 +144,8 @@ std::vector<std::shared_ptr<RayObject>> cast_to_task_args(void *ptr) {
 ObjectID _submit_task(const ray::JuliaFunctionDescriptor &jl_func_descriptor,
                       const std::vector<TaskArg *> &task_args,
                       const std::string &serialized_runtime_env_info,
-                      const std::unordered_map<std::string, double> &resources) {
+                      const std::unordered_map<std::string, double> &resources,
+                      int max_retries) {
 
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
@@ -171,8 +172,8 @@ ObjectID _submit_task(const ray::JuliaFunctionDescriptor &jl_func_descriptor,
         func,
         args,
         options,
-        /*max_retries=*/0,
-        /*retry_exceptions=*/false,
+        max_retries,                // application error counter, gate for OOM retry (!=0)
+        /*retry_exceptions=*/false, // only applies to application errors
         scheduling_strategy,
         /*debugger_breakpoint=*/""
     );

--- a/src/ray_julia_jll/common.jl
+++ b/src/ray_julia_jll/common.jl
@@ -373,10 +373,11 @@ end
 # XXX: Need to convert julia vectors to StdVector and build the
 # `std::unordered_map` for resources. This function helps us avoid having
 # CxxWrap as a direct dependency in Ray.jl
-function _submit_task(fd, args, serialized_runtime_env_info, resources::AbstractDict)
+function _submit_task(fd, args, serialized_runtime_env_info, resources::AbstractDict,
+                      max_retries)
     @debug "task resources: " resources
     resources = build_resource_requests(resources)
-    return _submit_task(fd, args, serialized_runtime_env_info, resources)
+    return _submit_task(fd, args, serialized_runtime_env_info, resources, max_retries)
 end
 
 # work around lack of wrapped `std::unordered_map`

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -140,7 +140,8 @@ initialize_coreworker_driver(args...) = ray_jll.initialize_coreworker_driver(arg
 # TODO: Move task related code into a "task.jl" file
 function submit_task(f::Function, args::Tuple, kwargs::NamedTuple=NamedTuple();
                      runtime_env::Union{RuntimeEnv,Nothing}=nothing,
-                     resources::Dict{String,Float64}=Dict("CPU" => 1.0))
+                     resources::Dict{String,Float64}=Dict("CPU" => 1.0),
+                     max_retries::Integer=0)
     export_function!(FUNCTION_MANAGER[], f, get_job_id())
     fd = ray_jll.function_descriptor(f)
     task_args = serialize_args(flatten_args(args, kwargs))
@@ -155,7 +156,8 @@ function submit_task(f::Function, args::Tuple, kwargs::NamedTuple=NamedTuple();
         ray_jll._submit_task(fd,
                              transform_task_args(task_args),
                              serialized_runtime_env_info,
-                             resources)
+                             resources,
+                             max_retries)
     end
     # CoreWorker::SubmitTask calls TaskManager::AddPendingTask which initializes
     # the local ref count to 1, so we don't need to do that here.


### PR DESCRIPTION
Fixes #213 and may fix #143 

Given that we're still forbidding retries of application errors, I'm not quite sure how to test this.