### PR TITLE
Use CxxWrap 0.14.2 for `StdVector` fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 [compat]
 Aqua = "0.5"
 ArgParse = "1"
-CxxWrap = "0.14.1"
+CxxWrap = "0.14.2"
 JSON3 = "1"
 LoggingExtras = "1"
 julia = "1.8"

--- a/build/Project.toml
+++ b/build/Project.toml
@@ -12,7 +12,7 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 CodecZlib = "0.7.3"
-CxxWrap = "0.14.1"
+CxxWrap = "0.14.2"
 Mustache = "1"
 Tar = "1"
 TOML = "1"

--- a/src/ray_serializer.jl
+++ b/src/ray_serializer.jl
@@ -94,13 +94,7 @@ function serialize_to_ray_object(data, metadata=nothing)
         ray_jll.NullPtr(ray_jll.Buffer)
     end
 
-    # https://github.com/JuliaInterop/CxxWrap.jl/issues/367
-    inlined_ids = if !isempty(s.object_ids)
-        StdVector(collect(s.object_ids))::StdVector{ray_jll.ObjectID}
-    else
-        StdVector{ray_jll.ObjectID}()
-    end
-
+    inlined_ids = StdVector{ray_jll.ObjectID}(collect(s.object_ids))
     worker = ray_jll.GetCoreWorker()
     inlined_refs = ray_jll.GetObjectRefs(worker, inlined_ids)
 


### PR DESCRIPTION
Uses the fix made in: https://github.com/JuliaInterop/CxxWrap.jl/pull/385