### PR TITLE
Allow user capture of `stderr` in `process_eval`

### DIFF
--- a/test/runtime.jl
+++ b/test/runtime.jl
@@ -29,7 +29,7 @@
 
     @testset "log to stderr" begin
         err = IOBuffer()
-        @process_eval stderr=err begin
+        @process_eval stderr = err begin
             using Ray
             Ray.init(; logs_dir="")
         end
@@ -40,7 +40,7 @@
 
     @testset "log to stderr: env var" begin
         err = IOBuffer()
-        @process_eval stderr=err begin
+        @process_eval stderr = err begin
             using Ray
             ENV[Ray.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE] = "1"
             Ray.init()

--- a/test/runtime.jl
+++ b/test/runtime.jl
@@ -8,13 +8,12 @@
     @testset "custom logs_dir" begin
         mktempdir() do logs_dir
             cp("/tmp/ray/session_latest/logs/raylet.out", joinpath(logs_dir, "raylet.out"))
+            err = IOBuffer()
             code = quote
                 using Ray
                 Ray.init(; logs_dir=$logs_dir)
             end
-            cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
-            err = IOBuffer()
-            run(pipeline(cmd; stderr=err))
+            process_eval(code; stderr=err)
 
             logfiles = readdir(logs_dir; join=true)
             @test count(contains("julia-core-driver"), logfiles) == 1
@@ -29,43 +28,37 @@
     end
 
     @testset "log to stderr" begin
-        code = quote
+        err = IOBuffer()
+        @process_eval stderr=err begin
             using Ray
             Ray.init(; logs_dir="")
         end
-        cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
-        out = IOBuffer()
-        err = IOBuffer()
-        run(pipeline(cmd; stdout=out, stderr=err))
+
         stderr_logs = String(take!(err))
         @test contains(stderr_logs, "Constructing CoreWorkerProcess")
     end
 
     @testset "log to stderr: env var" begin
-        code = quote
+        err = IOBuffer()
+        @process_eval stderr=err begin
             using Ray
             ENV[Ray.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE] = "1"
             Ray.init()
         end
-        cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
-        out = IOBuffer()
-        err = IOBuffer()
-        run(pipeline(cmd; stdout=out, stderr=err))
+
         stderr_logs = String(take!(err))
         @test contains(stderr_logs, "Constructing CoreWorkerProcess")
     end
 
     @testset "kwarg takes precedence over env var" begin
         mktempdir() do logs_dir
+            err = IOBuffer()
             code = quote
                 using Ray
                 ENV[Ray.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE] = "1"
                 Ray.init(; logs_dir=$logs_dir)
             end
-            cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
-            out = IOBuffer()
-            err = IOBuffer()
-            run(pipeline(cmd; stdout=out, stderr=err))
+            process_eval(code; stderr=err)
 
             logfiles = readdir(logs_dir; join=true)
             @test count(contains("julia-core-driver"), logfiles) == 1

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -35,12 +35,13 @@ local_count(oid_hex) = first(get(Ray.get_all_reference_counts(), oid_hex, 0))
 
 # Useful in running tests which require us to re-run `Ray.init` which currently can only be
 # called once as it is infeasible to reset global `Ref`'s using `isassigned` conditionals.
-macro process_eval(ex)
-    expr = QuoteNode(ex)
-    return esc(:(process_eval($expr)))
+macro process_eval(ex...)
+    kwargs = ex[1:(end - 1)]
+    expr = QuoteNode(ex[end])
+    return esc(:(process_eval($expr; $(kwargs...))))
 end
 
-function process_eval(expr::Expr; stdout=devnull)
+function process_eval(expr::Expr; stdout=devnull, stderr=devnull)
     # Avoid returning the result with STDOUT as other output and `atexit` hooks make it
     # difficult to read the serialized result.
     code = quote
@@ -74,17 +75,23 @@ function process_eval(expr::Expr; stdout=devnull)
     cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
 
     input = Pipe()
-    err = Pipe()
+    stderr = stderr === devnull ? Pipe() : stderr
     result_file = tempname()
-    p = run(pipeline(cmd; stdin=input, stdout=stdout, stderr=err); wait=false)
+    p = run(pipeline(cmd; stdin=input, stdout, stderr); wait=false)
 
     serialize(input, expr)
     serialize(input, result_file)
     wait(p)
     if success(p)
         return deserialize(result_file)
-    else
-        err_str = String(readavailable(err))
+    elseif stderr isa Pipe || stderr isa IOBuffer
+        err_str = if stderr isa Pipe
+            String(readavailable(stderr))
+        else
+            String(take!(stderr))
+        end
         error("Executing `process_eval` failed:\n\"\"\"\"\n$err_str\"\"\"\"")
+    else
+        error("Executing `process_eval` failed")
     end
 end


### PR DESCRIPTION
Use `process_eval` for all of our external Ray on Julia testing needs so that we get nicer reporting than this which was noticed on #214:
```
custom logs_dir: Error During Test at /Users/runner/work/Ray.jl/Ray.jl/test/runtime.jl:8
  Got exception outside of a @test
  failed process: Process(`/Users/runner/hostedtoolcache/julia/1.8.5/aarch64/bin/julia -Cnative -J/Users/runner/hostedtoolcache/julia/1.8.5/aarch64/lib/julia/sys.dylib --depwarn=yes --check-bounds=yes -g1 --code-coverage=user --color=yes --startup-file=no --project=/private/var/folders/ss/7dgwjb6s15n04v4v6nn0mxn00000gn/T/jl_OXOrae -e 'begin
      #= /Users/runner/work/Ray.jl/Ray.jl/test/runtime.jl:12 =#
      using Ray
      #= /Users/runner/work/Ray.jl/Ray.jl/test/runtime.jl:13 =#
      Ray.init(; logs_dir = "/var/folders/ss/7dgwjb6s15n04v4v6nn0mxn00000gn/T/jl_OpmTO7")
  end'`, ProcessExited(139)) [139]
  
  Stacktrace:
    [1] pipeline_error
      @ ./process.jl:565 [inlined]
    [2] run(::Base.CmdRedirect; wait::Bool)
      @ Base ./process.jl:480
    [3] run
      @ ./process.jl:477 [inlined]
    [4] (::var"#30#33")(logs_dir::String)
      @ Main ~/work/Ray.jl/Ray.jl/test/runtime.jl:17
    [5] mktempdir(fn::var"#30#33", parent::String; prefix::String)
      @ Base.Filesystem ./file.jl:764
    [6] mktempdir(fn::Function, parent::String) (repeats 2 times)
      @ Base.Filesystem ./file.jl:760
    [7] macro expansion
      @ ~/work/Ray.jl/Ray.jl/test/runtime.jl:9 [inlined]
    [8] macro expansion
      @ ~/hostedtoolcache/julia/1.8.5/aarch64/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
    [9] macro expansion
      @ ~/work/Ray.jl/Ray.jl/test/runtime.jl:9 [inlined]
   [10] macro expansion
      @ ~/hostedtoolcache/julia/1.8.5/aarch64/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
   [11] top-level scope
      @ ~/work/Ray.jl/Ray.jl/test/runtime.jl:2
   [12] include
      @ ./client.jl:476 [inlined]
   [13] #3
      @ ~/work/Ray.jl/Ray.jl/test/runtests.jl:36 [inlined]
   [14] setup_core_worker(body::var"#3#5")
      @ Main ~/work/Ray.jl/Ray.jl/test/utils.jl:19
   [15] #2
     @ ~/work/Ray.jl/Ray.jl/test/runtests.jl:33 [inlined]
   [16] setup_ray_head_node(body::var"#2#4")
      @ Main ~/work/Ray.jl/Ray.jl/test/utils.jl:10
   [17] macro expansion
      @ ~/work/Ray.jl/Ray.jl/test/runtests.jl:30 [inlined]
   [18] macro expansion
      @ ~/hostedtoolcache/julia/1.8.5/aarch64/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
   [19] top-level scope
      @ ~/work/Ray.jl/Ray.jl/test/runtests.jl:20
   [20] include(fname::String)
      @ Base.MainInclude ./client.jl:476
   [21] top-level scope
      @ none:6
   [22] eval
      @ ./boot.jl:368 [inlined]
   [23] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:276
   [24] _start()
      @ Base ./client.jl:522
```
– https://github.com/beacon-biosignals/Ray.jl/actions/runs/6641903107/job/18045441825?pr=214#step:12:226