### PR TITLE
GSC client refactor / Wrap `JuliaGcsClient::Del`

### DIFF
--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -317,6 +317,16 @@ std::vector<std::string> JuliaGcsClient::Keys(const std::string &ns, const std::
     return results;
 }
 
+void JuliaGcsClient::Del(const std::string &ns, const std::string &key, bool del_by_prefix) {
+    if (!gcs_client_) {
+        throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+    }
+    Status status = gcs_client_->InternalKV().Del(ns, key, del_by_prefix);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+}
+
 bool JuliaGcsClient::Exists(const std::string &ns, const std::string &key) {
     if (!gcs_client_) {
         throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
@@ -738,6 +748,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("Put", &JuliaGcsClient::Put)
         .method("Get", &JuliaGcsClient::Get)
         .method("Keys", &JuliaGcsClient::Keys)
+        .method("Del", &JuliaGcsClient::Del)
         .method("Exists", &JuliaGcsClient::Exists);
 
     mod.add_type<gcs::GcsClientOptions>("GcsClientOptions")

--- a/build/wrapper.cc
+++ b/build/wrapper.cc
@@ -297,12 +297,12 @@ bool JuliaGcsClient::Put(const std::string &ns,
     if (!gcs_client_) {
         throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
     }
-    bool added_num;
-    Status status = gcs_client_->InternalKV().Put(ns, key, value, overwrite, added_num);
+    bool added;
+    Status status = gcs_client_->InternalKV().Put(ns, key, value, overwrite, added);
     if (!status.ok()) {
         throw std::runtime_error(status.ToString());
     }
-    return added_num;
+    return added;
 }
 
 std::vector<std::string> JuliaGcsClient::Keys(const std::string &ns, const std::string &prefix) {

--- a/build/wrapper.h
+++ b/build/wrapper.h
@@ -61,7 +61,7 @@ class JuliaGcsClient {
                  bool overwrite);
 
         std::vector<std::string> Keys(const std::string &ns, const std::string &prefix);
-
+        void Del(const std::string &ns, const std::string &key, bool del_by_prefix);
         bool Exists(const std::string &ns, const std::string &key);
 
     private:

--- a/build/wrapper.h
+++ b/build/wrapper.h
@@ -35,39 +35,40 @@ std::string ToString(ray::FunctionDescriptor function_descriptor);
 // - gcs_rpc_server_reconnect_timeout_s (default 60): timeout for reconnecting to GCSClient
 // - gcs_server_request_timeout_seconds (default 60): timeout for fetching from GCSClient
 class JuliaGcsClient {
-public:
-    JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
-    JuliaGcsClient(const std::string &gcs_address);
+    public:
+        JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
+        JuliaGcsClient(const std::string &gcs_address);
 
-    ~JuliaGcsClient() {
-        // Automatically disconnect a client to avoid a SIGABRT (6)
-        // https://github.com/beacon-biosignals/Ray.jl/pull/211#issuecomment-1780070784
-        if (gcs_client_) {
-            std::cerr << "\x1B[31mWarning: Forgot to disconnect JuliaGcsClient\033[0m" << std::endl;
-            this->Disconnect();
+        ~JuliaGcsClient() {
+            // Automatically disconnect a client to avoid a SIGABRT (6)
+            // https://github.com/beacon-biosignals/Ray.jl/pull/211#issuecomment-1780070784
+            if (gcs_client_) {
+                std::cerr << "\x1B[31mWarning: Forgot to disconnect JuliaGcsClient\033[0m" << std::endl;
+                this->Disconnect();
+            }
         }
-    }
 
-    ray::Status Connect();
-    void Disconnect();
+        ray::Status Connect();
+        void Disconnect();
 
-    // Get, Put, Exists, Keys use methods belonging to an InternalKV field of the GCSClient
-    // https://github.com/beacon-biosignals/ray/blob/448a83caf44108fc1bc44fa7c6c358cffcfcb0d7/src/ray/gcs/gcs_client/accessor.h#L687
-    std::string Get(const std::string &ns, const std::string &key);
+        // Get, Put, Exists, Keys use methods belonging to an InternalKV field of the GCSClient
+        // https://github.com/beacon-biosignals/ray/blob/448a83caf44108fc1bc44fa7c6c358cffcfcb0d7/src/ray/gcs/gcs_client/accessor.h#L687
+        std::string Get(const std::string &ns, const std::string &key);
 
-    bool Put(const std::string &ns,
-            const std::string &key,
-            const std::string &value,
-            bool overwrite);
+        bool Put(const std::string &ns,
+                 const std::string &key,
+                 const std::string &value,
+                 bool overwrite);
 
-    std::vector<std::string> Keys(const std::string &ns, const std::string &prefix);
+        std::vector<std::string> Keys(const std::string &ns, const std::string &prefix);
 
-    bool Exists(const std::string &ns, const std::string &key);
+        bool Exists(const std::string &ns, const std::string &key);
 
-    std::unique_ptr<ray::gcs::GcsClient> gcs_client_;
-    ray::gcs::GcsClientOptions options_;
-    std::unique_ptr<instrumented_io_context> io_service_;
-    std::unique_ptr<std::thread> io_service_thread_;
+    private:
+        std::unique_ptr<ray::gcs::GcsClient> gcs_client_;
+        ray::gcs::GcsClientOptions options_;
+        std::unique_ptr<instrumented_io_context> io_service_;
+        std::unique_ptr<std::thread> io_service_thread_;
 };
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod);

--- a/test/function_manager.jl
+++ b/test/function_manager.jl
@@ -21,10 +21,10 @@
 
         # ensure function doesn't exist in GCS
         mfd = function_descriptor(MyMod.f)
-        ray_jll.Del(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, function_key(mfd, jobid), false)
+        mkey = function_key(mfd, jobid)
+        ray_jll.Del(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, mkey, false)
 
         @test_throws ErrorException import_function!(fm, mfd, jobid)
-        mkey = function_key(mfd, jobid)
         @test !ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, mkey)
         export_function!(fm, MyMod.f, jobid)
 

--- a/test/function_manager.jl
+++ b/test/function_manager.jl
@@ -22,7 +22,7 @@
         mfd = function_descriptor(MyMod.f)
         @test_throws ErrorException import_function!(fm, mfd, jobid)
         mkey = function_key(mfd, jobid)
-        @test !(ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, mkey))
+        @test !ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, mkey)
         export_function!(fm, MyMod.f, jobid)
 
         # can import the function even when it's aliased in another module:

--- a/test/function_manager.jl
+++ b/test/function_manager.jl
@@ -2,7 +2,7 @@
     using Ray: FUNCTION_MANAGER_NAMESPACE, FunctionManager, function_key, export_function!,
                import_function!
     using .ray_julia_jll: JuliaGcsClient, Connect, Disconnect, function_descriptor,
-                          JuliaFunctionDescriptor, Exists
+                          JuliaFunctionDescriptor
 
     Connect(JuliaGcsClient("127.0.0.1:6379")) do gcs_client
         fm = FunctionManager(gcs_client, Dict{String,Any}())
@@ -19,7 +19,10 @@
 
         @test f2.(1:10) == f.(1:10)
 
+        # ensure function doesn't exist in GCS
         mfd = function_descriptor(MyMod.f)
+        ray_jll.Del(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, function_key(mfd, jobid), false)
+
         @test_throws ErrorException import_function!(fm, mfd, jobid)
         mkey = function_key(mfd, jobid)
         @test !ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, mkey)

--- a/test/ray_julia_jll/gcs_client.jl
+++ b/test/ray_julia_jll/gcs_client.jl
@@ -1,7 +1,6 @@
 @testset "GCS client" begin
     using UUIDs
-    using .ray_julia_jll: JuliaGcsClient, Connect, Put, Get, Keys, Exists, Status, ok,
-                          ToString, Disconnect
+    using .ray_julia_jll: JuliaGcsClient, Connect, Disconnect, Del, Put, Get, Keys, Exists
 
     client = JuliaGcsClient("127.0.0.1:6379")
     @test isnothing(Disconnect(client))
@@ -42,8 +41,15 @@
         @test !Put(client, ns, "computer", "blah", true)
         @test Get(client, ns, "computer") == "blah"
 
+        # delete
+        result = Del(client, ns, "computer", false)
+        @test result isa Nothing
+        @test !Exists(client, ns, "computer")
+
+        # deleting a non-existent key doesn't fail
+        Del(client, ns, "computer", false)
 
         # throw on missing key
-        @test_throws ErrorException Get(client, ns, "none")
+        @test_throws ErrorException Get(client, ns, "computer")
     end
 end

--- a/test/ray_julia_jll/gcs_client.jl
+++ b/test/ray_julia_jll/gcs_client.jl
@@ -15,20 +15,33 @@
     @test_throws ErrorException Exists(client, ns, "computer")
 
     Connect(client) do client
-        @test Put(client, ns, "computer", "mistaek", false) == 1
-        @test Get(client, ns, "computer") == "mistaek"
-        @test Keys(client, ns, "") == ["computer"]
+        added = Put(client, ns, "computer", "mistaek", false)
+        @test added isa Bool
+        @test added == true
+
+        result = Get(client, ns, "computer")
+        @test result isa StdString
+        @test result == "mistaek"
+
+        results = Keys(client, ns, "")
+        @test results isa StdVector{StdString}
+        @test results == ["computer"]
+
         @test Keys(client, ns, "comp") == ["computer"]
         @test Keys(client, ns, "comppp") == []
-        @test Exists(client, ns, "computer")
+
+        exists = Exists(client, ns, "computer")
+        @test exists isa Bool
+        @test exists == true
 
         # no overwrite
-        @test Put(client, ns, "computer", "blah", false) == 0
+        @test !Put(client, ns, "computer", "blah", false)
         @test Get(client, ns, "computer") == "mistaek"
 
         # overwrite ("added" only increments on new key I think)
-        @test Put(client, ns, "computer", "blah", true) == 0
+        @test !Put(client, ns, "computer", "blah", true)
         @test Get(client, ns, "computer") == "blah"
+
 
         # throw on missing key
         @test_throws ErrorException Get(client, ns, "none")


### PR DESCRIPTION
Follow up to #211 and fixes a long standing issue with locally testing with a persistent Ray head node between tests runs